### PR TITLE
Make replay cleanup interruption-safe

### DIFF
--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -149,17 +149,36 @@ export const live = Layer.effect(
       ) {
         const current = yield* run("git", ["branch", "--show-current"]);
         const temp = `stack/replay-${Date.now()}-${branch.replaceAll("/", "-")}`;
+        const abortCherryPick = run("git", ["cherry-pick", "--abort"], [
+          0,
+          1,
+          128,
+        ]).pipe(Effect.asVoid, Effect.orDie);
+        const deleteTemp = run("git", ["branch", "-D", temp], [0, 1]).pipe(
+          Effect.asVoid,
+          Effect.orDie,
+        );
+        const restoreCurrent = current
+          ? run("git", ["checkout", current]).pipe(Effect.asVoid, Effect.orDie)
+          : Effect.void;
 
-        yield* run("git", ["checkout", "-B", temp, parent]).pipe(Effect.asVoid);
-        if (commits.length > 0) {
-          yield* run("git", ["cherry-pick", "--empty=drop", ...commits]).pipe(
+        yield* Effect.gen(function* () {
+          yield* run("git", ["checkout", "-B", temp, parent]).pipe(
             Effect.asVoid,
           );
-        }
-        yield* run("git", ["branch", "-f", branch, temp]).pipe(Effect.asVoid);
-        if (current)
-          yield* run("git", ["checkout", current]).pipe(Effect.asVoid);
-        yield* run("git", ["branch", "-D", temp], [0, 1]).pipe(Effect.asVoid);
+          if (commits.length > 0) {
+            yield* run("git", ["cherry-pick", "--empty=drop", ...commits]).pipe(
+              Effect.asVoid,
+            );
+          }
+          yield* run("git", ["branch", "-f", branch, temp]).pipe(Effect.asVoid);
+        }).pipe(
+          Effect.ensuring(
+            abortCherryPick.pipe(
+              Effect.ensuring(restoreCurrent.pipe(Effect.ensuring(deleteTemp))),
+            ),
+          ),
+        );
       });
       const backup = Effect.fn("Git.backup")((branch: string, name: string) =>
         run("git", ["branch", "-f", name, branch]).pipe(Effect.asVoid),

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1145,6 +1145,50 @@ describe("StackGraph", () => {
   });
 });
 
+describe("Git", () => {
+  it.effect("replay restores current branch and deletes temp branch after failure", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.gen(function* () {
+            calls.push([tool, ...args]);
+            if (args[0] === "branch" && args[1] === "--show-current") {
+              return "stack-c";
+            }
+            if (args[0] === "cherry-pick" && args[1] !== "--abort") {
+              return yield* Effect.fail(new ExecError(tool, args, 1, "conflict"));
+            }
+            return "";
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const git = yield* Git.Service;
+
+      const error = yield* Effect.flip(git.replay("stack-b", "dev", ["b1"]));
+
+      expect(error).toBeInstanceOf(ExecError);
+      const temp = calls[1]?.[3];
+      expect(temp).toMatch(/^stack\/replay-\d+-stack-b$/);
+      expect(calls).toEqual([
+        ["git", "branch", "--show-current"],
+        ["git", "checkout", "-B", temp, "dev"],
+        ["git", "cherry-pick", "--empty=drop", "b1"],
+        ["git", "cherry-pick", "--abort"],
+        ["git", "checkout", "stack-c"],
+        ["git", "branch", "-D", temp],
+      ]);
+    }).pipe(
+      Effect.provide(
+        Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc)),
+      ),
+    );
+  });
+});
+
 describe("Stack", () => {
   it.effect("status uses local stack metadata without inferring from GitHub", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- Ensure `Git.replay` always aborts in-progress cherry-picks, restores the original branch, and deletes the temporary replay branch.
- Add regression coverage for replay failure cleanup.

## Verification
- `bun run typecheck`
- `bun run test`
- `bun src/cli.ts --help`
- `bun src/cli.ts sync --help`
- `bun src/cli.ts merge --help`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#1** 👈 current
2. #2
3. #3
4. #4
5. #5
<!-- stack:links:end -->