### PR TITLE
Use Effect clock for stack timestamps

### DIFF
--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -1,4 +1,5 @@
 import * as Context from "effect/Context";
+import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -148,7 +149,8 @@ export const live = Layer.effect(
         commits: ReadonlyArray<string>,
       ) {
         const current = yield* run("git", ["branch", "--show-current"]);
-        const temp = `stack/replay-${Date.now()}-${branch.replaceAll("/", "-")}`;
+        const now = yield* Clock.currentTimeMillis;
+        const temp = `stack/replay-${now}-${branch.replaceAll("/", "-")}`;
         const abortCherryPick = run("git", ["cherry-pick", "--abort"], [
           0,
           1,

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1,4 +1,5 @@
 import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -113,6 +114,10 @@ ${note}`;
             `The PR did not merge immediately. If checks are still running or the PR is waiting on required reviews, use: stack merge --auto\n` +
             `If you intentionally want to bypass GitHub merge requirements with admin privileges, use: stack merge --apply --admin`,
         );
+      const timestamp = Effect.fn("Stack.timestamp")(function* () {
+        const now = yield* DateTime.nowAsDate;
+        return now.toISOString().replaceAll(":", "").replaceAll(".", "");
+      });
 
       const githubPullBase = (remote: string) => {
         const https = remote.match(
@@ -403,10 +408,7 @@ ${note}`;
             const journalState = opts.journalState ?? state;
             const initialActions = opts.initialActions ?? [];
             const mode: StackResult.Mode = apply ? "apply" : "dry-run";
-            const stamp = new Date()
-              .toISOString()
-              .replaceAll(":", "")
-              .replaceAll(".", "");
+            const stamp = yield* timestamp();
             const actions: Array<StackResult.StackResultItem> =
               Array.from(initialActions);
             const links = new Map(
@@ -1042,10 +1044,7 @@ ${note}`;
             }
 
             const root = cfg.trunks[0] ?? branchName("dev");
-            const stamp = new Date()
-              .toISOString()
-              .replaceAll(":", "")
-              .replaceAll(".", "");
+            const stamp = yield* timestamp();
             const name = `backup/landed-${stamp}-${target}`;
             const hasLocalTarget = refs.some((item) => item.name === target);
             const next =

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Layer, Option, Ref } from "effect";
+import { TestClock } from "effect/testing";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1166,13 +1167,14 @@ describe("Git", () => {
     );
 
     return Effect.gen(function* () {
+      yield* TestClock.setTime(1_700_000_000_000);
       const git = yield* Git.Service;
 
       const error = yield* Effect.flip(git.replay("stack-b", "dev", ["b1"]));
 
       expect(error).toBeInstanceOf(ExecError);
       const temp = calls[1]?.[3];
-      expect(temp).toMatch(/^stack\/replay-\d+-stack-b$/);
+      expect(temp).toBe("stack/replay-1700000000000-stack-b");
       expect(calls).toEqual([
         ["git", "branch", "--show-current"],
         ["git", "checkout", "-B", temp, "dev"],


### PR DESCRIPTION
## Summary
- Replace ambient `Date.now()` / `new Date()` usage in core services with Effect clock-backed time.
- Make replay temp branch names deterministic under `TestClock`.

## Verification
- `bun run typecheck`
- `bun run test`
- `bun src/cli.ts --help`
- `bun src/cli.ts sync --help`
- `bun src/cli.ts merge --help`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1
2. **#2** 👈 current
3. #3
4. #4
5. #5
<!-- stack:links:end -->