### PR TITLE
Tighten typed error channels

### DIFF
--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -199,6 +199,51 @@ export class DirtyWorktreeError extends Schema.TaggedErrorClass<DirtyWorktreeErr
   }
 }
 
+export class StackOperationError extends Schema.TaggedErrorClass<StackOperationError>()(
+  "StackOperationError",
+  {
+    message: Schema.String,
+  },
+) {
+  constructor(message: string) {
+    super({ message });
+  }
+}
+
+export class GitHubDecodeError extends Schema.TaggedErrorClass<GitHubDecodeError>()(
+  "GitHubDecodeError",
+  {
+    args: Schema.Array(Schema.String),
+    output: Schema.String,
+    detail: Schema.String,
+    message: Schema.String,
+  },
+) {
+  constructor(
+    readonly args: ReadonlyArray<string>,
+    readonly output: string,
+    readonly detail: string,
+  ) {
+    super({
+      args: Array.from(args),
+      output,
+      detail,
+      message: `gh ${args.join(" ")} returned invalid JSON`,
+    });
+  }
+}
+
+export type StoreError = StateError;
+export type GitHubError = ExecError | GitHubDecodeError;
+export type StackError =
+  | ExecError
+  | GitHubDecodeError
+  | StateError
+  | BranchError
+  | MergeBaseError
+  | DirtyWorktreeError
+  | StackOperationError;
+
 export const stackState = (links: ReadonlyArray<StackLink>) =>
   new StackState({ version, links: Array.from(links) });
 

--- a/src/services/GitHub.ts
+++ b/src/services/GitHub.ts
@@ -5,6 +5,8 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import {
   ExecError,
+  GitHubDecodeError,
+  type GitHubError,
   PullLabel,
   pullMeta,
   PullMeta,
@@ -15,24 +17,24 @@ import * as Proc from "../platform/proc.ts";
 import { StackConfig } from "./Config.ts";
 
 export interface Interface {
-  readonly auto: (pr: number) => Effect.Effect<void, ExecError>;
+  readonly auto: (pr: number) => Effect.Effect<void, GitHubError>;
   readonly merge: (
     pr: number,
     opts?: { readonly admin?: boolean },
-  ) => Effect.Effect<void, ExecError>;
-  readonly wait: (pr: number) => Effect.Effect<void, ExecError>;
-  readonly pulls: () => Effect.Effect<ReadonlyArray<PullRef>, ExecError>;
-  readonly pull: (pr: number) => Effect.Effect<PullMeta, ExecError>;
-  readonly edit: (pr: number, base: string) => Effect.Effect<void, ExecError>;
-  readonly body: (pr: number, body: string) => Effect.Effect<void, ExecError>;
-  readonly close: (pr: number) => Effect.Effect<void, ExecError>;
+  ) => Effect.Effect<void, GitHubError>;
+  readonly wait: (pr: number) => Effect.Effect<void, GitHubError>;
+  readonly pulls: () => Effect.Effect<ReadonlyArray<PullRef>, GitHubError>;
+  readonly pull: (pr: number) => Effect.Effect<PullMeta, GitHubError>;
+  readonly edit: (pr: number, base: string) => Effect.Effect<void, GitHubError>;
+  readonly body: (pr: number, body: string) => Effect.Effect<void, GitHubError>;
+  readonly close: (pr: number) => Effect.Effect<void, GitHubError>;
   readonly create: (
     branch: string,
     base: string,
     title: string,
     body: string,
     labels: ReadonlyArray<string>,
-  ) => Effect.Effect<PullRef, ExecError>;
+  ) => Effect.Effect<PullRef, GitHubError>;
 }
 
 class PullData extends Schema.Class<PullData>("PullData")({
@@ -64,6 +66,30 @@ class PullWatch extends Schema.Class<PullWatch>("PullWatch")({
 }) {}
 
 const PullListJson = Schema.Array(PullData);
+
+const decodePullList = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(PullListJson)(JSON.parse(out)),
+    catch: (err) => new GitHubDecodeError(args, out, String(err)),
+  });
+
+const decodePullView = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(PullView)(JSON.parse(out)),
+    catch: (err) => new GitHubDecodeError(args, out, String(err)),
+  });
+
+const decodePullWatch = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(PullWatch)(JSON.parse(out)),
+    catch: (err) => new GitHubDecodeError(args, out, String(err)),
+  });
+
+const decodePullData = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(PullData)(JSON.parse(out)),
+    catch: (err) => new GitHubDecodeError(args, out, String(err)),
+  });
 
 const ref = (row: PullData) =>
   pullRef({
@@ -105,7 +131,7 @@ export const layer = Layer.effect(
       });
 
       const pulls = Effect.fn("GitHub.pulls")(function* () {
-        const out = yield* run([
+        const args = [
           "pr",
           "list",
           "--state",
@@ -114,33 +140,27 @@ export const layer = Layer.effect(
           "number,headRefName,baseRefName,url,isDraft",
           "--limit",
           "200",
-        ]);
+        ];
+        const out = yield* run(args);
 
-        const rows = yield* Effect.try({
-          try: () => Schema.decodeUnknownSync(PullListJson)(JSON.parse(out)),
-          catch: (err) => new ExecError("gh", ["pr", "list"], 1, String(err)),
-        });
+        const rows = yield* decodePullList(args, out);
 
         return rows.map(ref);
       });
 
-      const pull = Effect.fn("GitHub.pull")((pr: number) =>
-        run([
+      const pull = Effect.fn("GitHub.pull")((pr: number) => {
+        const args = [
           "pr",
           "view",
           `${pr}`,
           "--json",
           "number,title,body,headRefName,baseRefName,url,isDraft,labels",
-        ]).pipe(
-          Effect.flatMap((out) =>
-            Effect.try({
-              try: () => meta(Schema.decodeUnknownSync(PullView)(JSON.parse(out))),
-              catch: (err) =>
-                new ExecError("gh", ["pr", "view", `${pr}`], 1, String(err)),
-            }),
-          ),
-        ),
-      );
+        ];
+        return run(args).pipe(
+          Effect.flatMap((out) => decodePullView(args, out)),
+          Effect.map(meta),
+        );
+      });
 
       const auto = Effect.fn("GitHub.auto")((pr: number) =>
         run([
@@ -170,18 +190,15 @@ export const layer = Layer.effect(
       const wait = Effect.fn("GitHub.wait")((pr: number) =>
         Effect.gen(function* () {
           for (;;) {
-            const out = yield* run([
+            const args = [
               "pr",
               "view",
               `${pr}`,
               "--json",
               "state,mergedAt",
-            ]);
-            const row = yield* Effect.try({
-              try: () => Schema.decodeUnknownSync(PullWatch)(JSON.parse(out)),
-              catch: (err) =>
-                new ExecError("gh", ["pr", "view", `${pr}`], 1, String(err)),
-            });
+            ];
+            const out = yield* run(args);
+            const row = yield* decodePullWatch(args, out);
 
             if (row.mergedAt) return;
             if (row.state !== "OPEN") {
@@ -233,19 +250,16 @@ export const layer = Layer.effect(
           ...labels.flatMap((label) => ["--label", label]),
         ]);
 
-        const out = yield* run([
+        const args = [
           "pr",
           "view",
           branch,
           "--json",
           "number,headRefName,baseRefName,url,isDraft",
-        ]);
+        ];
+        const out = yield* run(args);
 
-        const row = yield* Effect.try({
-          try: () => Schema.decodeUnknownSync(PullData)(JSON.parse(out)),
-          catch: (err) =>
-            new ExecError("gh", ["pr", "view", branch], 1, String(err)),
-        });
+        const row = yield* decodePullData(args, out);
 
         return ref(row);
       });

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -15,6 +15,8 @@ import {
   PullRef,
   stackLink,
   StackLink,
+  StackOperationError,
+  type StackError,
   stackState,
   StatusReport,
   UndoEntry,
@@ -33,14 +35,14 @@ import * as Progress from "./Progress.ts";
 import { Store } from "./Store.ts";
 
 export interface StackService {
-  readonly status: () => Effect.Effect<StatusReport, unknown>;
+  readonly status: () => Effect.Effect<StatusReport, StackError>;
   readonly adopt: (
     branch: string,
     parent: string,
-  ) => Effect.Effect<StackLink, unknown>;
+  ) => Effect.Effect<StackLink, StackError>;
   readonly links: (
     apply?: boolean,
-  ) => Effect.Effect<ReadonlyArray<string>, unknown>;
+  ) => Effect.Effect<ReadonlyArray<string>, StackError>;
   readonly land: (
     branch?: string,
     opts?: {
@@ -48,18 +50,18 @@ export interface StackService {
       readonly auto?: boolean;
       readonly admin?: boolean;
     },
-  ) => Effect.Effect<ReadonlyArray<string>, unknown>;
+  ) => Effect.Effect<ReadonlyArray<string>, StackError>;
   readonly sync: (
     opts?: { readonly dryRun?: boolean },
-  ) => Effect.Effect<ReadonlyArray<string>, unknown>;
-  readonly doctor: () => Effect.Effect<ReadonlyArray<string>, unknown>;
+  ) => Effect.Effect<ReadonlyArray<string>, StackError>;
+  readonly doctor: () => Effect.Effect<ReadonlyArray<string>, StackError>;
   readonly repair: (
     apply?: boolean,
-  ) => Effect.Effect<ReadonlyArray<string>, unknown>;
-  readonly last: () => Effect.Effect<ReadonlyArray<string>, unknown>;
+  ) => Effect.Effect<ReadonlyArray<string>, StackError>;
+  readonly last: () => Effect.Effect<ReadonlyArray<string>, StackError>;
   readonly undo: (
     apply?: boolean,
-  ) => Effect.Effect<ReadonlyArray<string>, unknown>;
+  ) => Effect.Effect<ReadonlyArray<string>, StackError>;
 }
 
 export class Stack extends Context.Service<Stack, StackService>()("@stack/Stack") {
@@ -109,11 +111,14 @@ ${note}`;
       const wait = (message: string) =>
         progress.emit({ _tag: "Wait", message });
       const mergeFailure = (err: unknown) =>
-        new Error(
+        new StackOperationError(
           `${err instanceof Error ? err.message : String(err)}\n\n` +
             `The PR did not merge immediately. If checks are still running or the PR is waiting on required reviews, use: stack merge --auto\n` +
             `If you intentionally want to bypass GitHub merge requirements with admin privileges, use: stack merge --apply --admin`,
         );
+      const missingPull = (err: StackError) =>
+        err._tag === "ExecError" &&
+        /not found|could not resolve|no pull request/i.test(err.stderr);
       const timestamp = Effect.fn("Stack.timestamp")(function* () {
         const now = yield* DateTime.nowAsDate;
         return now.toISOString().replaceAll(":", "").replaceAll(".", "");
@@ -166,12 +171,12 @@ ${note}`;
           const refs = yield* git.refs();
           if (trunk(branch)) {
             return yield* Effect.fail(
-              new Error(`cannot track trunk branch: ${branch}`),
+              new StackOperationError(`cannot track trunk branch: ${branch}`),
             );
           }
           if (branch === parent) {
             return yield* Effect.fail(
-              new Error(`${branch} cannot be its own parent`),
+              new StackOperationError(`${branch} cannot be its own parent`),
             );
           }
           if (!refs.some((ref) => ref.name === branch))
@@ -202,7 +207,9 @@ ${note}`;
             )
           ) {
             return yield* Effect.fail(
-              new Error(`tracking ${branch} onto ${parent} would create a cycle`),
+              new StackOperationError(
+                `tracking ${branch} onto ${parent} would create a cycle`,
+              ),
             );
           }
           const pr = pulls.find((pull) => pull.head === branch)?.number ?? null;
@@ -615,7 +622,7 @@ ${note}`;
                     ? yield* github
                         .pull(link.pr)
                         .pipe(
-                          Effect.catch(() =>
+                          Effect.catchIf(missingPull, () =>
                             Effect.succeed<PullMeta | null>(null),
                           ),
                         )
@@ -789,7 +796,7 @@ ${note}`;
                 ? Effect.void
                 : step(`restore branch ${current}`).pipe(
                     Effect.flatMap(() => git.switch(current)),
-                    Effect.catch(() => Effect.void),
+                    Effect.catchTag("ExecError", () => Effect.void),
                   ),
             ),
           );
@@ -814,7 +821,7 @@ ${note}`;
                 .map((pr) =>
                   github
                     .pull(pr)
-                    .pipe(Effect.catch(() => Effect.succeed(null))),
+                    .pipe(Effect.catchIf(missingPull, () => Effect.succeed(null))),
                 ),
               { concurrency: "unbounded" },
             );
@@ -972,12 +979,12 @@ ${note}`;
             const admin = opts?.admin ?? false;
             if (apply && auto) {
               return yield* Effect.fail(
-                new Error("use either --apply or --auto, not both"),
+                new StackOperationError("use either --apply or --auto, not both"),
               );
             }
             if (admin && !apply) {
               return yield* Effect.fail(
-                new Error("use --admin only with --apply"),
+                new StackOperationError("use --admin only with --apply"),
               );
             }
             const active = apply || auto;
@@ -1011,7 +1018,7 @@ ${note}`;
             if (!branch && !state.links.some((item) => item.branch === target)) {
               if (roots.length > 1) {
                 return yield* Effect.fail(
-                  new Error(
+                  new StackOperationError(
                     `multiple stack roots found: ${roots.join(", ")}. run: stack merge <branch>`,
                   ),
                 );
@@ -1025,21 +1032,23 @@ ${note}`;
                 return yield* Effect.fail(new BranchError(target));
               const parent = pr?.base ?? String(cfg.trunks[0] ?? "dev");
               return yield* Effect.fail(
-                new Error(
+                new StackOperationError(
                   `${target} is not tracked in stack state. status can infer it, but merge needs an explicit link. run: stack track ${target} --onto ${parent}`,
                 ),
               );
             }
             if (!trunk(link.parent)) {
               return yield* Effect.fail(
-                new Error(`${target} is not the oldest branch in its stack`),
+                new StackOperationError(
+                  `${target} is not the oldest branch in its stack`,
+                ),
               );
             }
 
             const pr = pulls.find((item) => item.head === target) ?? null;
             if (!pr) {
               return yield* Effect.fail(
-                new Error(`no open PR found for ${target}`),
+                new StackOperationError(`no open PR found for ${target}`),
               );
             }
 

--- a/src/services/Store.ts
+++ b/src/services/Store.ts
@@ -8,17 +8,18 @@ import * as Schema from "effect/Schema";
 import {
   stackState,
   StackState,
+  type StoreError,
   StateError,
   UndoState,
 } from "../domain/model.ts";
 import { StackConfig } from "./Config.ts";
 
 export interface StoreService {
-  readonly read: () => Effect.Effect<StackState, unknown>;
-  readonly write: (state: StackState) => Effect.Effect<void, unknown>;
-  readonly readUndo: () => Effect.Effect<UndoState | null, unknown>;
-  readonly writeUndo: (state: UndoState) => Effect.Effect<void, unknown>;
-  readonly clearUndo: () => Effect.Effect<void, unknown>;
+  readonly read: () => Effect.Effect<StackState, StoreError>;
+  readonly write: (state: StackState) => Effect.Effect<void, StoreError>;
+  readonly readUndo: () => Effect.Effect<UndoState | null, StoreError>;
+  readonly writeUndo: (state: UndoState) => Effect.Effect<void, StoreError>;
+  readonly clearUndo: () => Effect.Effect<void, StoreError>;
 }
 
 const empty = () => stackState([]);
@@ -37,7 +38,13 @@ export class Store extends Context.Service<Store, StoreService>()("@stack/Store"
         parse: (raw: string) => A,
       ) =>
         Effect.gen(function* () {
-          const has = yield* fs.exists(file);
+          const has = yield* fs
+            .exists(file)
+            .pipe(
+              Effect.mapError(
+                (err) => new StateError(file, "exists", String(err)),
+              ),
+            );
           if (!has) return miss();
 
           const raw = yield* fs
@@ -99,7 +106,9 @@ export class Store extends Context.Service<Store, StoreService>()("@stack/Store"
       );
 
       const clearUndo = Effect.fn("Store.clearUndo")(() =>
-        fs.remove(cfg.journal).pipe(Effect.catch(() => Effect.void)),
+        fs.remove(cfg.journal).pipe(
+          Effect.catchTag("PlatformError", () => Effect.void),
+        ),
       );
 
       return Store.of({ read, write, readUndo, writeUndo, clearUndo });


### PR DESCRIPTION
## Summary
- Replace broad `unknown` service error channels with explicit error unions.
- Add typed operation/decode errors and narrow broad catches to expected recoverable cases.

## Verification
- `bun run typecheck`
- `bun run test`
- `bun src/cli.ts --help`
- `bun src/cli.ts sync --help`
- `bun src/cli.ts merge --help`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1
2. #2
3. #3
4. **#4** 👈 current
5. #5
<!-- stack:links:end -->