### PR TITLE
Configure GitHub polling and concurrency

### DIFF
--- a/src/services/Config.ts
+++ b/src/services/Config.ts
@@ -13,6 +13,8 @@ export interface StackConfigService {
   readonly store: string;
   readonly journal: string;
   readonly trunks: ReadonlyArray<BranchName>;
+  readonly githubConcurrency: number;
+  readonly githubWaitIntervalMillis: number;
 }
 
 export class StackConfig extends Context.Service<
@@ -24,6 +26,8 @@ export class StackConfig extends Context.Service<
     store?: string;
     journal?: string;
     trunks?: ReadonlyArray<string>;
+    githubConcurrency?: number;
+    githubWaitIntervalMillis?: number;
   }) =>
     Layer.effect(
       StackConfig,
@@ -36,6 +40,8 @@ export class StackConfig extends Context.Service<
           journal:
             opts.journal ?? path.join(opts.root, ".git", "stack", "undo.json"),
           trunks: (opts.trunks ?? trunks).map((name) => branchName(name)),
+          githubConcurrency: opts.githubConcurrency ?? 4,
+          githubWaitIntervalMillis: opts.githubWaitIntervalMillis ?? 5_000,
         });
       }),
     );

--- a/src/services/GitHub.ts
+++ b/src/services/GitHub.ts
@@ -212,7 +212,7 @@ export const layer = Layer.effect(
               );
             }
 
-            yield* Effect.sleep(5000);
+            yield* Effect.sleep(cfg.githubWaitIntervalMillis);
           }
         }),
       );

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -823,7 +823,7 @@ ${note}`;
                     .pull(pr)
                     .pipe(Effect.catchIf(missingPull, () => Effect.succeed(null))),
                 ),
-              { concurrency: "unbounded" },
+              { concurrency: cfg.githubConcurrency },
             );
             const metas = new Map(
               info
@@ -875,7 +875,9 @@ ${note}`;
                 }),
               );
 
-            const items = yield* Effect.all(jobs, { concurrency: "unbounded" });
+            const items = yield* Effect.all(jobs, {
+              concurrency: cfg.githubConcurrency,
+            });
             const actions = items.filter((item): item is string =>
               Boolean(item),
             );

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Effect, Layer, Option, Ref } from "effect";
+import { Effect, Fiber, Layer, Option, Ref } from "effect";
 import { TestClock } from "effect/testing";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -1186,6 +1186,52 @@ describe("Git", () => {
     }).pipe(
       Effect.provide(
         Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc)),
+      ),
+    );
+  });
+});
+
+describe("GitHub", () => {
+  it.effect("wait polls with the configured interval", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    let views = 0;
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            views += 1;
+            return JSON.stringify({
+              state: "OPEN",
+              mergedAt: views === 1 ? null : "2026-01-01T00:00:00Z",
+            });
+          }),
+      }),
+    );
+    const cfgLayer = StackConfig.layer({
+      root: "/tmp/stack",
+      trunks: ["dev"],
+      githubWaitIntervalMillis: 1_000,
+    }).pipe(Layer.provide(NodeServices.layer));
+
+    return Effect.gen(function* () {
+      const github = yield* GitHub.Service;
+      const fiber = yield* github.wait(4).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Effect.yieldNow;
+      expect(calls).toHaveLength(1);
+
+      yield* TestClock.adjust("999 millis");
+      expect(calls).toHaveLength(1);
+
+      yield* TestClock.adjust("1 millis");
+      yield* Fiber.join(fiber);
+      expect(calls).toHaveLength(2);
+    }).pipe(
+      Effect.provide(
+        GitHub.layer.pipe(Layer.provideMerge(cfgLayer), Layer.provideMerge(proc)),
       ),
     );
   });


### PR DESCRIPTION
## Summary
- Add config defaults for GitHub polling interval and bounded GitHub concurrency.
- Replace unbounded PR metadata fanout and add `TestClock` coverage for polling.

## Verification
- `bun run typecheck`
- `bun run test`
- `bun src/cli.ts --help`
- `bun src/cli.ts sync --help`
- `bun src/cli.ts merge --help`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1
2. #2
3. #3
4. #4
5. **#5** 👈 current
<!-- stack:links:end -->