### PR TITLE
Scope merge repair to the selected stack

### DIFF
--- a/.changeset/scope-merge-repair.md
+++ b/.changeset/scope-merge-repair.md
@@ -2,4 +2,4 @@
 "stack": patch
 ---
 
-Scope merge descendant repair and stack-block refreshes to the selected stack so independent recorded stacks are not rewritten.
+Scope repair and stack-block refreshes to the selected stack, and update blocks for PRs recreated during repair.

--- a/.changeset/scope-merge-repair.md
+++ b/.changeset/scope-merge-repair.md
@@ -1,0 +1,5 @@
+---
+"stack": patch
+---
+
+Scope merge descendant repair and stack-block refreshes to the selected stack so independent recorded stacks are not rewritten.

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1339,6 +1339,9 @@ ${note}`;
               );
             }
 
+            const branches = scopedBranches(state, target);
+            const scopedState = filterState(state, branches);
+
             const pr = pulls.find((item) => item.head === target) ?? null;
             if (!pr) {
               return yield* Effect.fail(new StackOperationError(`no open PR found for ${target}`));
@@ -1348,9 +1351,9 @@ ${note}`;
             const stamp = yield* timestamp();
             const name = `backup/landed-${stamp}-${target}`;
             const hasLocalTarget = refs.some((item) => item.name === target);
-            const next = state.links.find((item) => item.parent === target)?.branch ?? null;
+            const next = scopedState.links.find((item) => item.parent === target)?.branch ?? null;
             const landed = new Set([`#${pr.number}`, String(target)]);
-            const preRetargets = state.links
+            const preRetargets = scopedState.links
               .filter((item) => item.parent === target)
               .flatMap((child) => {
                 const childPr = pulls.find((item) => item.head === child.branch);
@@ -1407,13 +1410,33 @@ ${note}`;
                   git.refs(),
                   github.pulls(),
                 ]);
+                const scopedNextState = filterState(nextState, branches);
                 const repair = yield* repairStack(
-                  nextState,
+                  scopedNextState,
                   nextRefs.filter((item) => item.name !== target),
-                  nextPulls.filter((item) => item.head !== target),
-                  { apply: true, saved: new Map([[target, name]]) },
+                  nextPulls.filter(
+                    (item) => item.head !== target && branches.has(String(item.head)),
+                  ),
+                  {
+                    apply: true,
+                    saved: new Map([[target, name]]),
+                    journalState: nextState,
+                    writeState: (next) =>
+                      store
+                        .read()
+                        .pipe(
+                          Effect.flatMap((latest) =>
+                            store.write(mergeState(latest, branches, next)),
+                          ),
+                        ),
+                  },
                 );
-                const notes = yield* linksFor(null, true, landed);
+                const notes = yield* linksFor(
+                  repair.state,
+                  true,
+                  landed,
+                  nextPulls.filter((item) => branches.has(String(item.head))),
+                );
                 if (current !== target) yield* git.switch(current);
                 const tail = next ? `next root: ${next}` : "next root: none";
                 const view = yield* diagram();
@@ -1462,9 +1485,11 @@ ${note}`;
             }
 
             const repair = yield* repairStack(
-              state,
+              scopedState,
               refs.filter((item) => item.name !== target),
-              plannedPulls.filter((item) => item.head !== target),
+              plannedPulls.filter(
+                (item) => item.head !== target && branches.has(String(item.head)),
+              ),
               { apply: false },
             );
             const tail = next ? `next root: ${next}` : "next root: none";

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -290,6 +290,13 @@ ${note}`;
           scoped.links,
         );
 
+      const writeScopedState = (branches: ReadonlySet<string>) =>
+        Effect.fn("Stack.writeScopedState")((next: ReturnType<typeof stackState>) =>
+          store
+            .read()
+            .pipe(Effect.flatMap((latest) => store.write(mergeState(latest, branches, next)))),
+        );
+
       const actionBranch = (action: StackResult.StackResultItem) => {
         switch (action._tag) {
           case "Text":
@@ -965,16 +972,7 @@ ${note}`;
                         ),
                       )
                     : reconciled.replayAnchors;
-                  const writeState = target
-                    ? (next: ReturnType<typeof stackState>) =>
-                        store
-                          .read()
-                          .pipe(
-                            Effect.flatMap((latest) =>
-                              store.write(mergeState(latest, target.branches, next)),
-                            ),
-                          )
-                    : undefined;
+                  const writeState = target ? writeScopedState(target.branches) : undefined;
                   const repair = yield* repairStack(scoped, refs, pulls, {
                     apply: !dryRun,
                     journalState: state,
@@ -983,7 +981,15 @@ ${note}`;
                     ...(writeState ? { writeState } : {}),
                     preserveUndo,
                   });
-                  const notes = yield* linksFor(scoped, !dryRun, new Set(), pulls);
+                  const notesPulls = dryRun ? pulls : yield* github.pulls();
+                  const notes = yield* linksFor(
+                    repair.state,
+                    !dryRun,
+                    new Set(),
+                    target
+                      ? notesPulls.filter((pull) => target.branches.has(String(pull.head)))
+                      : notesPulls,
+                  );
                   const changed = repair.actions.length > 0 || notes.actions.length > 0;
                   const lines = !changed
                     ? renderSyncTree({
@@ -1421,21 +1427,15 @@ ${note}`;
                     apply: true,
                     saved: new Map([[target, name]]),
                     journalState: nextState,
-                    writeState: (next) =>
-                      store
-                        .read()
-                        .pipe(
-                          Effect.flatMap((latest) =>
-                            store.write(mergeState(latest, branches, next)),
-                          ),
-                        ),
+                    writeState: writeScopedState(branches),
                   },
                 );
+                const repairedPulls = yield* github.pulls();
                 const notes = yield* linksFor(
                   repair.state,
                   true,
                   landed,
-                  nextPulls.filter((item) => branches.has(String(item.head))),
+                  repairedPulls.filter((item) => branches.has(String(item.head))),
                 );
                 if (current !== target) yield* git.switch(current);
                 const tail = next ? `next root: ${next}` : "next root: none";

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1474,6 +1474,54 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("scoped sync ignores stale and independent recorded stacks", () => {
+    const layer = stackTestLayer({
+      current: "active-child",
+      refs: [
+        ref("dev", "dev-new"),
+        ref("active-root", "active-root"),
+        ref("active-child", "active-child"),
+        ref("other-root", "other-root"),
+        ref("other-child", "other-child"),
+        ref("stale", "stale"),
+      ],
+      pulls: [
+        pr(1, "active-root", "dev"),
+        pr(2, "active-child", "active-root"),
+        pr(3, "other-root", "dev"),
+        pr(4, "other-child", "other-root"),
+      ],
+      bases: bases(
+        ["active-root", "dev", "dev-new"],
+        ["active-child", "active-root", "active-root"],
+        ["other-root", "dev", "dev-old"],
+        ["other-child", "other-root", "other-old"],
+      ),
+      state: stackState([
+        stackLink({ branch: "active-root", parent: "dev", anchor: "dev-new", pr: 1 }),
+        stackLink({ branch: "active-child", parent: "active-root", anchor: "active-root", pr: 2 }),
+        stackLink({ branch: "other-root", parent: "dev", anchor: "dev-old", pr: 3 }),
+        stackLink({ branch: "other-child", parent: "other-root", anchor: "other-old", pr: 4 }),
+        stackLink({ branch: "stale", parent: "dev", anchor: "dev-old", pr: 5 }),
+      ]),
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const store = yield* Store;
+      const items = yield* stack.sync({ branch: "active-child", dryRun: true });
+      const output = items.join("\n");
+      const state = yield* store.read();
+
+      expect(output).toContain("active-root");
+      expect(output).toContain("active-child");
+      expect(output).not.toContain("other-root");
+      expect(output).not.toContain("other-child");
+      expect(output).not.toContain("stale");
+      expect(state.links.map((link) => String(link.branch))).toContain("stale");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync branch argument rejects branches outside tracked stacks", () => {
     const layer = stackTestLayer({
       current: "dev",
@@ -2110,6 +2158,66 @@ describe("Stack", () => {
       expect(plan).toContain("would merge #4 (stack-a)");
       expect(plan).toContain("next root: stack-b");
     }).pipe(Effect.provide(test.layer));
+  });
+
+  it.effect("land repair only plans and applies descendants of the selected stack", () => {
+    const seen: Array<string> = [];
+    const layer = stackTestLayer({
+      current: "active-child",
+      refs: [
+        ref("dev", "dev-new"),
+        ref("active-root", "active-root"),
+        ref("active-child", "active-child"),
+        ref("other-root", "other-root"),
+        ref("other-child", "other-child"),
+      ],
+      pulls: [
+        pr(1, "active-root", "dev"),
+        pr(2, "active-child", "active-root"),
+        pr(3, "other-root", "dev"),
+        pr(4, "other-child", "other-root"),
+      ],
+      bases: bases(
+        ["active-root", "dev", "dev-new"],
+        ["active-child", "active-root", "active-root"],
+        ["other-root", "dev", "dev-old"],
+        ["other-child", "other-root", "other-old"],
+      ),
+      state: stackState([
+        stackLink({ branch: "active-root", parent: "dev", anchor: "dev-new", pr: 1 }),
+        stackLink({ branch: "active-child", parent: "active-root", anchor: "active-root", pr: 2 }),
+        stackLink({ branch: "other-root", parent: "dev", anchor: "dev-old", pr: 3 }),
+        stackLink({ branch: "other-child", parent: "other-root", anchor: "other-old", pr: 4 }),
+      ]),
+      service: {
+        replay: (branch) => Effect.sync(() => void seen.push(`rebase ${branch}`)),
+        push: (branch) => Effect.sync(() => void seen.push(`push ${branch}`)),
+        body: (number) => Effect.sync(() => void seen.push(`body ${number}`)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const store = yield* Store;
+      const output = (yield* stack.land("active-root")).join("\n");
+
+      expect(output).toContain("would merge #1 (active-root)");
+      expect(output).toContain("would rebase active-child onto dev");
+      expect(output).not.toContain("other-root");
+      expect(output).not.toContain("other-child");
+
+      yield* stack.land("active-root", { apply: true });
+      const state = yield* store.read();
+      expect(seen).toContain("rebase active-child");
+      expect(seen).toContain("push active-child");
+      expect(seen).toContain("body 2");
+      expect(seen.join("\n")).not.toContain("other-root");
+      expect(seen.join("\n")).not.toContain("other-child");
+      expect(seen).not.toContain("body 3");
+      expect(seen).not.toContain("body 4");
+      expect(state.links.map((link) => String(link.branch))).toContain("other-root");
+      expect(state.links.map((link) => String(link.branch))).toContain("other-child");
+    }).pipe(Effect.provide(layer));
   });
 
   it.effect("land infers the only stack root when current branch is off-stack", () => {

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1522,6 +1522,51 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("sync refreshes stack blocks for pull requests created during repair", () => {
+    const seen: Array<string> = [];
+    let pulls = [pr(2, "active-child", "active-root")];
+    const layer = stackTestLayer({
+      current: "active-child",
+      refs: [
+        ref("dev", "dev-new"),
+        ref("active-root", "active-root"),
+        ref("active-child", "active-child"),
+      ],
+      pulls,
+      bases: bases(
+        ["active-root", "dev", "dev-old"],
+        ["active-child", "active-root", "active-root"],
+      ),
+      state: stackState([
+        stackLink({ branch: "active-root", parent: "dev", anchor: "dev-old", pr: null }),
+        stackLink({ branch: "active-child", parent: "active-root", anchor: "active-root", pr: 2 }),
+      ]),
+      service: {
+        pulls: () => Effect.succeed(pulls),
+        pull: (number) => {
+          const found = pulls.find((item) => item.number === number);
+          return found
+            ? Effect.succeed(metaFor(found))
+            : Effect.fail(new ExecError("gh", ["pr", "view", `${number}`], 1, "not found"));
+        },
+        create: (branch, base) =>
+          Effect.sync(() => {
+            const made = pr(3, branch, base);
+            pulls = [...pulls, made];
+            return made;
+          }),
+        body: (number) => Effect.sync(() => void seen.push(`body ${number}`)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.sync({ branch: "active-child" });
+
+      expect(seen).toContain("body 3");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync branch argument rejects branches outside tracked stacks", () => {
     const layer = stackTestLayer({
       current: "dev",
@@ -2217,6 +2262,55 @@ describe("Stack", () => {
       expect(seen).not.toContain("body 4");
       expect(state.links.map((link) => String(link.branch))).toContain("other-root");
       expect(state.links.map((link) => String(link.branch))).toContain("other-child");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("land refreshes stack blocks for pull requests recreated during repair", () => {
+    const seen: Array<string> = [];
+    let pulls = [pr(1, "active-root", "dev")];
+    const layer = stackTestLayer({
+      current: "active-child",
+      refs: [
+        ref("dev", "dev-new"),
+        ref("active-root", "active-root"),
+        ref("active-child", "active-child"),
+      ],
+      pulls,
+      bases: bases(
+        ["active-root", "dev", "dev-new"],
+        ["active-child", "active-root", "active-root"],
+      ),
+      state: stackState([
+        stackLink({ branch: "active-root", parent: "dev", anchor: "dev-new", pr: 1 }),
+        stackLink({ branch: "active-child", parent: "active-root", anchor: "active-root", pr: 2 }),
+      ]),
+      service: {
+        pulls: () => Effect.succeed(pulls),
+        merge: (number) =>
+          Effect.sync(() => {
+            pulls = pulls.filter((item) => item.number !== number);
+          }),
+        pull: (number) => {
+          const found = pulls.find((item) => item.number === number);
+          return found
+            ? Effect.succeed(metaFor(found))
+            : Effect.fail(new ExecError("gh", ["pr", "view", `${number}`], 1, "not found"));
+        },
+        create: (branch, base) =>
+          Effect.sync(() => {
+            const made = pr(5, branch, base);
+            pulls = [...pulls, made];
+            return made;
+          }),
+        body: (number) => Effect.sync(() => void seen.push(`body ${number}`)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.land("active-root", { apply: true });
+
+      expect(seen).toContain("body 5");
     }).pipe(Effect.provide(layer));
   });
 


### PR DESCRIPTION
## Summary
- limit merge descendant repair and stack-block refreshes to the selected recorded stack
- preserve unrelated stack metadata while applying scoped repair
- refresh stack blocks from repaired PR state, including PRs recreated during repair

## Root cause
Merge-triggered repair passed the complete persisted stack state into the repair planner and body updater, allowing independent recorded stacks to be rewritten. Scoped sync already isolated recorded stacks on main, but used pre-repair PR state for body updates.

## Verification
- bun run typecheck
- bun run test
- bun run format:check
- bun run lint
- bun src/cli.ts sync --help
- bun src/cli.ts merge --help