### PR TITLE
Remove link from stack block heading

### DIFF
--- a/src/stackBlock.ts
+++ b/src/stackBlock.ts
@@ -2,7 +2,7 @@ import { PullMeta, PullRef } from "./domain/model.ts";
 
 const start = "<!-- stack:links:start -->";
 const end = "<!-- stack:links:end -->";
-const heading = "### [Stack](https://github.com/kitlangton/stack)";
+const heading = "### Stack";
 
 const inlineTitle = (value: string | null) => {
   const title = value?.replace(/\s+/g, " ").trim();

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -661,7 +661,7 @@ Footer
             }),
           body: (pr: number, body: string) =>
             Effect.sync(() => {
-              seen.push(`body ${pr} ${body.includes("### [Stack]")}`);
+              seen.push(`body ${pr} ${body.includes("### Stack")}`);
               bodies.set(pr, body);
               const current = metas.get(pr)!;
               metas.set(
@@ -884,7 +884,7 @@ const makeLand = (
               );
             }),
           body: (pr: number, body: string) =>
-            Effect.sync(() => void seen.push(`body ${pr} ${body.includes("### [Stack]")}`)),
+            Effect.sync(() => void seen.push(`body ${pr} ${body.includes("### Stack")}`)),
           close: () => Effect.void,
           create: (
             branch: string,
@@ -2767,7 +2767,8 @@ describe("Stack", () => {
       expect(body.match(/<!-- stack:links:start -->/g)).toHaveLength(1);
       expect(body.match(/<!-- stack:links:end -->/g)).toHaveLength(1);
       expect(body).not.toContain("old stack block");
-      expect(body).toContain("### [Stack](https://github.com/kitlangton/stack)");
+      expect(body).toContain("### Stack");
+      expect(body).not.toContain("https://github.com/kitlangton/stack");
     }).pipe(Effect.provide(test.layer));
   });
 
@@ -4355,7 +4356,7 @@ describe("StackBlock", () => {
     const previous = `body before
 
 <!-- stack:links:start -->
-### [Stack](https://github.com/kitlangton/stack)
+### Stack
 
 1. !1
 2. !2 - Already titled
@@ -4384,7 +4385,7 @@ describe("StackBlock", () => {
     const previous = `body before
 
 <!-- stack:links:start -->
-### [Stack](https://github.com/kitlangton/stack)
+### Stack
 
 1. !1
 2. !2
@@ -4405,7 +4406,7 @@ describe("StackBlock", () => {
     const previous = `body before
 
 <!-- stack:links:start -->
-### [Stack](https://github.com/kitlangton/stack)
+### Stack
 
 1. #1
 2. #2


### PR DESCRIPTION
## Summary
- render stack block headings as plain `### Stack`
- update stack block tests to assert the project URL is no longer emitted

## Rationale

I just noticed that when I'm using this tool, the project URL is always put in my PRs and I really don't like this.

The tool is nice but I don't want to fork the project just to get rid of this behavior.

I understand that it would help advertise the tool, but it seems disingenuous to force this behavior on users. I think it would be better to rely on the goodwill of your users to promote the tool due to how nice it is otherwise.

## Verification
- `bunx vitest run tests/stack.test.ts -t StackBlock`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run test`

---

##  [stack](https://github.com/kitlangton/stack) (before https://github.com/kitlangton/stack/pull/10)

## stack (after https://github.com/kitlangton/stack/pull/10)