### PR TITLE
Support configurable develop trunk

### DIFF
--- a/.changeset/slow-rings-develop.md
+++ b/.changeset/slow-rings-develop.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Allow repos to configure trunk branches with `git config stack.trunks`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 - Bare `stack sync` must stay non-mutating, including scoped and keep-going runs.
 - Mutating commands need an explicit mode: `--apply`, or `merge --auto` for code-host auto-merge plus descendant repair.
-- Never mutate trunk branches like `dev`, `main`, or `master`.
+- Never mutate configured trunk branches like `dev`, `main`, or `master`.
 - Before rebasing a branch, create a local backup branch.
 - Before repair mutates Git or a hosted change, save an undo checkpoint. Merge child retargets use a pre-merge recovery journal; after the root lands, descendant repair starts from a post-merge baseline that never retargets children back onto the landed branch.
 - `stack undo` should restore the last applied mutation from the saved journal.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ git config stack.codeHost github  # or: gitlab
 
 Use `STACK_CODE_HOST=github|gitlab` for a one-off override.
 
+## Trunk Branches
+
+By default, `stack` treats `dev`, `main`, and `master` as trunk branches. Repos
+that use another trunk, such as `develop`, can configure the trunk list:
+
+```bash
+git config stack.trunks dev,develop,main,master
+```
+
 ## Example Output
 
 ```text

--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -19,6 +19,8 @@ Install and authenticate the matching CLI before running `stack`. The
 `github.com` and `gitlab.com` hosts are detected automatically from `origin`.
 For an enterprise host, run `git config stack.codeHost github` or `git config
 stack.codeHost gitlab`; `STACK_CODE_HOST` is available as a temporary override.
+Repos that use a trunk outside the default `dev`, `main`, and `master` set can
+configure trunks with `git config stack.trunks dev,develop,main,master`.
 
 Keep ordinary editing and commits on plain `git`. Use `stack` only for stack
 intent, stack inspection, sync, merge, and undo workflows.
@@ -229,7 +231,7 @@ stack blocks.
 - `stack merge` is dry-run by default.
 - Mutating commands need `--apply`, except `stack merge --auto` waits for the code
   host and repairs descendants after the root lands.
-- Never mutate trunk branches such as `dev`, `main`, or `master`.
+- Never mutate configured trunk branches such as `dev`, `main`, or `master`.
 - Before rebasing a branch, the tool creates a local backup branch.
 - If output is unclear, inspect with `stack status`, `stack history`, or command
   help before applying.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import pkg from "../package.json" with { type: "json" };
 import { BranchError, DirtyWorktreeError, ExecError, MergeBaseError } from "./domain/model.ts";
 import { renderStatus } from "./format.ts";
 import * as Proc from "./platform/proc.ts";
-import { StackConfig, trunks } from "./services/Config.ts";
+import { parseTrunksConfig, StackConfig, trunks } from "./services/Config.ts";
 import { CodeHost } from "./services/CodeHost.ts";
 import { CodeHostGitHub } from "./services/code-host/GitHub.ts";
 import { CodeHostGitLab } from "./services/code-host/GitLab.ts";
@@ -329,12 +329,19 @@ const live = (() => {
 
       const dir = yield* proc.exec(root, "git", ["rev-parse", "--git-common-dir"]);
       const git = path.isAbsolute(dir) ? dir : path.join(root, dir);
+      const configuredTrunksOut = yield* proc.exec(
+        root,
+        "git",
+        ["config", "--get", "stack.trunks"],
+        [0, 1],
+      );
+      const configuredTrunks = parseTrunksConfig(configuredTrunksOut);
 
       return StackConfig.layer({
         root,
         store: path.join(git, "stack", "state.json"),
         journal: path.join(git, "stack", "undo.json"),
-        trunks,
+        trunks: configuredTrunks.length > 0 ? configuredTrunks : trunks,
       });
     }),
   ).pipe(Layer.provideMerge(proc));

--- a/src/services/Config.ts
+++ b/src/services/Config.ts
@@ -4,9 +4,15 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import { branchName, type BranchName } from "../domain/model.ts";
 
-export type Trunk = "dev" | "main" | "master";
+export type Trunk = "dev" | "develop" | "main" | "master";
 
-export const trunks: ReadonlyArray<Trunk> = ["dev", "main", "master"];
+export const trunks: ReadonlyArray<Exclude<Trunk, "develop">> = ["dev", "main", "master"];
+
+export const parseTrunksConfig = (value: string): ReadonlyArray<string> =>
+  value
+    .split(/[\s,]+/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
 
 export interface StackConfigService {
   readonly root: string;

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -23,7 +23,7 @@ import * as Proc from "../src/platform/proc.ts";
 import { RepairExecution } from "../src/repairExecution.ts";
 import * as StackBlock from "../src/stackBlock.ts";
 import * as StackGraph from "../src/stackGraph.ts";
-import { StackConfig } from "../src/services/Config.ts";
+import { parseTrunksConfig, StackConfig, trunks } from "../src/services/Config.ts";
 import { CodeHost } from "../src/services/CodeHost.ts";
 import { CodeHostGitHub } from "../src/services/code-host/GitHub.ts";
 import { CodeHostGitLab } from "../src/services/code-host/GitLab.ts";
@@ -1104,6 +1104,21 @@ const makeSyncNovel = () => {
     ),
   };
 };
+
+describe("StackConfig", () => {
+  it("does not include develop in default trunks", () => {
+    expect(trunks).toEqual(["dev", "main", "master"]);
+  });
+
+  it("parses configured trunks", () => {
+    expect(parseTrunksConfig("dev,develop main\nmaster")).toEqual([
+      "dev",
+      "develop",
+      "main",
+      "master",
+    ]);
+  });
+});
 
 describe("StackGraph", () => {
   it("builds status nodes from explicit and inferred parents", () => {


### PR DESCRIPTION
## Summary
Add support for configuring trunk branches with `git config stack.trunks`. In my projects, we use 'develop' as the base, rather than 'dev'. The hard coded list is a bit limiting.

## Example
`git config stack.trunks dev,develop,main,master`