### PR TITLE
Read raw remote URLs for repository matching

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -345,7 +345,7 @@ const live = (() => {
       const proc = yield* Proc.Service;
       const cfgValue = yield* StackConfig;
       const remoteOut = yield* proc
-        .exec(cfgValue.root, "git", ["remote", "get-url", "origin"], [0, 1])
+        .exec(cfgValue.root, "git", ["config", "--get", "remote.origin.url"], [0, 1])
         .pipe(Effect.catch(() => Effect.succeed("")));
       const configuredOut = yield* proc.exec(
         cfgValue.root,

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -81,7 +81,7 @@ export const live = Layer.effect(
 
     const current = Effect.fn("Git.current")(() => run("git", ["branch", "--show-current"]));
     const remote = Effect.fn("Git.remote")(() =>
-      run("git", ["remote", "get-url", "origin"], [0, 1]).pipe(
+      run("git", ["config", "--get", "remote.origin.url"], [0, 1]).pipe(
         Effect.map((out) => (out ? Option.some(out) : Option.none<string>())),
       ),
     );
@@ -92,13 +92,13 @@ export const live = Layer.effect(
       run("git", ["fetch", "origin", "--prune"]).pipe(Effect.asVoid),
     );
     const remotes = Effect.fn("Git.remotes")(() =>
-      run("git", ["remote", "-v"], [0, 1]).pipe(
+      run("git", ["config", "--get-regexp", "^remote\\..*\\.url$"], [0, 1]).pipe(
         Effect.map((out) => {
           const map = new Map<string, string>();
           for (const line of out.split("\n").filter(Boolean)) {
-            const match = line.match(/^(\S+)\s+(\S+)\s+\((fetch|push)\)$/);
+            const match = line.match(/^remote\.(.+)\.url\s+(.+)$/);
             if (!match) continue;
-            if (match[3] === "push" || !map.has(match[1]!)) map.set(match[1]!, match[2]!);
+            map.set(match[1]!, match[2]!);
           }
           return [...map].map(([name, url]) => ({ name, url }));
         }),

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -92,13 +92,13 @@ export const live = Layer.effect(
       run("git", ["fetch", "origin", "--prune"]).pipe(Effect.asVoid),
     );
     const remotes = Effect.fn("Git.remotes")(() =>
-      run("git", ["config", "--get-regexp", "^remote\\..*\\.url$"], [0, 1]).pipe(
+      run("git", ["config", "--get-regexp", "^remote\\..*\\.(push)?url$"], [0, 1]).pipe(
         Effect.map((out) => {
           const map = new Map<string, string>();
           for (const line of out.split("\n").filter(Boolean)) {
-            const match = line.match(/^remote\.(.+)\.url\s+(.+)$/);
+            const match = line.match(/^remote\.(.+)\.(push)?url\s+(.+)$/);
             if (!match) continue;
-            map.set(match[1]!, match[2]!);
+            if (match[2] === "push" || !map.has(match[1]!)) map.set(match[1]!, match[3]!);
           }
           return [...map].map(([name, url]) => ({ name, url }));
         }),

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -506,6 +506,45 @@ const make = (state = new StackState({ version: 1, links: [] })) =>
     Layer.provideMerge(Store.memory(state)),
   );
 
+describe("Git", () => {
+  it.effect("reads raw configured remote URLs before Git insteadOf rewrites", () =>
+    Effect.gen(function* () {
+      const root = yield* tempDir();
+      const repo = join(root, "repo");
+
+      yield* mkdirp(repo);
+      yield* shell(repo, "git", ["init", "-b", "main"]);
+      yield* shell(repo, "git", ["remote", "add", "origin", "git@github.com:example/repo.git"]);
+      yield* shell(repo, "git", [
+        "config",
+        "url.github-work:example/.insteadOf",
+        "git@github.com:example/",
+      ]);
+
+      expect(yield* shell(repo, "git", ["remote", "get-url", "origin"])).toBe(
+        "github-work:example/repo.git",
+      );
+
+      const cfgLayer = StackConfig.layer({ root: repo, trunks: ["main"] }).pipe(
+        Layer.provide(NodeServices.layer),
+      );
+      const result = yield* Effect.gen(function* () {
+        const git = yield* Git.Service;
+        const remote = yield* git.remote();
+        const remotes = yield* git.remotes();
+        return { remote, remotes };
+      }).pipe(
+        Effect.provide(Git.live.pipe(Layer.provide(cfgLayer))),
+        Effect.provide(Proc.live),
+        Effect.provide(NodeServices.layer),
+      );
+
+      expect(Option.getOrUndefined(result.remote)).toBe("git@github.com:example/repo.git");
+      expect(result.remotes).toEqual([{ name: "origin", url: "git@github.com:example/repo.git" }]);
+    }).pipe(Effect.provide(platform)),
+  );
+});
+
 const makeSync = (codeHost: Partial<CodeHost.Interface> = {}) => {
   const seen: Array<string> = [];
   const bodies = new Map<number, string>();

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -543,6 +543,38 @@ describe("Git", () => {
       expect(result.remotes).toEqual([{ name: "origin", url: "git@github.com:example/repo.git" }]);
     }).pipe(Effect.provide(platform)),
   );
+
+  it.effect("prefers raw push URLs when enumerating remotes", () =>
+    Effect.gen(function* () {
+      const root = yield* tempDir();
+      const repo = join(root, "repo");
+
+      yield* mkdirp(repo);
+      yield* shell(repo, "git", ["init", "-b", "main"]);
+      yield* shell(repo, "git", ["remote", "add", "origin", "git@github.com:upstream/repo.git"]);
+      yield* shell(repo, "git", [
+        "remote",
+        "set-url",
+        "--push",
+        "origin",
+        "git@github.com:fork/repo.git",
+      ]);
+
+      const cfgLayer = StackConfig.layer({ root: repo, trunks: ["main"] }).pipe(
+        Layer.provide(NodeServices.layer),
+      );
+      const remotes = yield* Effect.gen(function* () {
+        const git = yield* Git.Service;
+        return yield* git.remotes();
+      }).pipe(
+        Effect.provide(Git.live.pipe(Layer.provide(cfgLayer))),
+        Effect.provide(Proc.live),
+        Effect.provide(NodeServices.layer),
+      );
+
+      expect(remotes).toEqual([{ name: "origin", url: "git@github.com:fork/repo.git" }]);
+    }).pipe(Effect.provide(platform)),
+  );
 });
 
 const makeSync = (codeHost: Partial<CodeHost.Interface> = {}) => {


### PR DESCRIPTION
Git `insteadOf` rewrites and custom SSH host aliases can obscure repository identity. In that setup, Git may report a rewritten remote such as `github-work:example/repo.git`, while the configured remote still identifies the repository as `git@github.com:example/repo.git`. Repository matching should use the configured identity so fork/head remote inference remains stable.

This is handled through the following changes:
- read raw configured Git remote URLs from `remote.*.url` instead of rewrite-expanded `git remote get-url` / `git remote -v` output
- use the raw origin URL for live code-host provider detection
- add a focused test for an `insteadOf` rewrite that turns a normal GitHub scp remote into a custom SSH alias