### PR TITLE
fix(stack): support mixed stack topology

### DIFF
--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1338,7 +1338,7 @@ ${note}`;
                     StackBlock.render({
                       pulls: selectedPulls,
                       metas,
-                      chain: graph.explicitChainFor(String(pull.head)),
+                      chain: graph.displayChainFor(String(pull.head)),
                       completed,
                       branch: String(pull.head),
                       previous: meta.body,
@@ -1496,15 +1496,14 @@ ${note}`;
                 null)
               : null;
             const throughBranch = byPr ? String(byPr) : input;
-            const chain = graph.explicitChainFor(target);
+            const chain = graph.pathTo(throughBranch);
             const targetIndex = chain.indexOf(target);
-            const throughIndex = chain.indexOf(throughBranch);
-            if (throughIndex === -1 || throughIndex < targetIndex) {
+            if (targetIndex === -1) {
               return yield* Effect.fail(
                 new StackOperationError(`${through} is not in the current stack from ${target}`),
               );
             }
-            return throughBranch;
+            return { stop: throughBranch, chain: chain.slice(targetIndex) };
           }),
       );
 
@@ -1768,20 +1767,21 @@ ${note}`;
             return yield* Effect.fail(new StackOperationError("use --through only with --auto"));
           }
 
-          const stop = yield* throughTarget(branch, through);
+          const { stop, chain } = yield* throughTarget(branch, through);
           const items = new Array<string>();
-          let nextBranch = branch;
 
-          for (;;) {
-            const { target } = yield* landTarget(nextBranch);
+          for (const target of chain) {
             if (items.length > 0) items.push("");
             items.push(...(yield* landOne(target, { auto: true })));
             if (target === stop) {
               items.push(`merged through: ${stop}`);
               return items;
             }
-            nextBranch = undefined;
           }
+
+          return yield* Effect.fail(
+            new StackOperationError(`${through} is not in the current stack from ${chain[0]}`),
+          );
         });
       });
 

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1773,15 +1773,10 @@ ${note}`;
           for (const target of chain) {
             if (items.length > 0) items.push("");
             items.push(...(yield* landOne(target, { auto: true })));
-            if (target === stop) {
-              items.push(`merged through: ${stop}`);
-              return items;
-            }
           }
 
-          return yield* Effect.fail(
-            new StackOperationError(`${through} is not in the current stack from ${chain[0]}`),
-          );
+          items.push(`merged through: ${stop}`);
+          return items;
         });
       });
 

--- a/src/stackGraph.ts
+++ b/src/stackGraph.ts
@@ -29,7 +29,8 @@ export interface StatusTree {
 export interface StackGraph {
   readonly report: StatusReport;
   readonly tree: StatusTree;
-  readonly explicitChainFor: (branch: string) => ReadonlyArray<string>;
+  readonly pathTo: (branch: string) => ReadonlyArray<string>;
+  readonly displayChainFor: (branch: string) => ReadonlyArray<string>;
   readonly rank: (branch: string) => number;
   readonly rootOf: (branch: string) => string;
   readonly wouldCreateCycle: (branch: string, parent: string) => boolean;
@@ -158,28 +159,45 @@ export const make = (input: StackGraphInput): StackGraph => {
   });
   const tree = treeFromStatus(report);
 
-  const explicitChainFor = (branch: string) => {
-    let root = branch;
-    const seenRoots = new Set<string>();
-    for (;;) {
-      if (seenRoots.has(root)) break;
-      seenRoots.add(root);
-      const link = links.get(root);
+  const pathTo = (branch: string) => {
+    const chain = new Array<string>();
+    const seen = new Set<string>();
+    let name: string | null = branch;
+
+    while (name) {
+      if (seen.has(name)) break;
+      seen.add(name);
+      chain.push(name);
+      const link = links.get(name);
       if (!link || trunks.has(String(link.parent))) break;
-      root = String(link.parent);
+      name = String(link.parent);
     }
 
-    const chain = [root];
-    const seenChain = new Set(chain);
+    return chain.reverse();
+  };
+
+  const children = new Map<string, Array<string>>();
+  for (const link of input.state.links) {
+    const parent = String(link.parent);
+    const list = children.get(parent) ?? [];
+    list.push(String(link.branch));
+    children.set(parent, list);
+  }
+  for (const list of children.values()) list.sort((a, b) => a.localeCompare(b));
+
+  const displayChainFor = (branch: string) => {
+    const chain = Array.from(pathTo(branch));
+    const seen = new Set(chain);
+    let name = branch;
+
     for (;;) {
-      const next = input.state.links.find(
-        (link) => String(link.parent) === chain[chain.length - 1],
-      );
-      if (!next) break;
-      const name = String(next.branch);
-      if (seenChain.has(name)) break;
-      seenChain.add(name);
-      chain.push(name);
+      const kids = children.get(name) ?? [];
+      if (kids.length !== 1) break;
+      const child = kids[0]!;
+      if (seen.has(child)) break;
+      seen.add(child);
+      chain.push(child);
+      name = child;
     }
 
     return chain;
@@ -209,7 +227,8 @@ export const make = (input: StackGraphInput): StackGraph => {
   return {
     report,
     tree,
-    explicitChainFor,
+    pathTo,
+    displayChainFor,
     rank,
     rootOf,
     wouldCreateCycle: (branch: string, parent: string) =>

--- a/src/stackGraph.ts
+++ b/src/stackGraph.ts
@@ -176,14 +176,14 @@ export const make = (input: StackGraphInput): StackGraph => {
     return chain.reverse();
   };
 
-  const children = new Map<string, Array<string>>();
+  const explicitChildren = new Map<string, Array<string>>();
   for (const link of input.state.links) {
     const parent = String(link.parent);
-    const list = children.get(parent) ?? [];
+    const list = explicitChildren.get(parent) ?? [];
     list.push(String(link.branch));
-    children.set(parent, list);
+    explicitChildren.set(parent, list);
   }
-  for (const list of children.values()) list.sort((a, b) => a.localeCompare(b));
+  for (const list of explicitChildren.values()) list.sort((a, b) => a.localeCompare(b));
 
   const displayChainFor = (branch: string) => {
     const chain = Array.from(pathTo(branch));
@@ -191,7 +191,7 @@ export const make = (input: StackGraphInput): StackGraph => {
     let name = branch;
 
     for (;;) {
-      const kids = children.get(name) ?? [];
+      const kids = explicitChildren.get(name) ?? [];
       if (kids.length !== 1) break;
       const child = kids[0]!;
       if (seen.has(child)) break;

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -754,6 +754,8 @@ const makeLand = (
   currentBranch = "stack-a",
   progress: Array<Progress.ProgressEvent> | null = null,
   codeHost: Partial<CodeHost.Interface> = {},
+  includeUnrelatedRoot = false,
+  forkStackC = false,
 ) => {
   const seen: Array<string> = [];
   const refs = new Map([
@@ -762,6 +764,9 @@ const makeLand = (
     ["stack-b", branchRef({ name: "stack-b", head: "stack-b-1" })],
     ["stack-c", branchRef({ name: "stack-c", head: "stack-c-1" })],
   ]);
+  if (includeUnrelatedRoot) {
+    refs.set("other-root", branchRef({ name: "other-root", head: "other-root-1" }));
+  }
   let pulls = [
     pullRef({
       number: 4,
@@ -780,18 +785,64 @@ const makeLand = (
     pullRef({
       number: 3,
       head: "stack-c",
-      base: "stack-b",
+      base: forkStackC ? "stack-a" : "stack-b",
       url: "u3",
       draft: false,
     }),
   ];
+  if (includeUnrelatedRoot) {
+    pulls = [
+      ...pulls,
+      pullRef({
+        number: 9,
+        head: "other-root",
+        base: "dev",
+        url: "u9",
+        draft: false,
+      }),
+    ];
+  }
   const bases = new Map([
     ["stack-a:dev", "dev-1"],
     ["stack-b:stack-a", "stack-a-1"],
+    ["stack-c:stack-a", "stack-a-1"],
     ["stack-c:stack-b", "stack-b-1"],
     ["stack-b:dev", "dev-1"],
   ]);
+  if (includeUnrelatedRoot) {
+    bases.set("other-root:dev", "dev-1");
+  }
   let merged = false;
+  const links = [
+    stackLink({
+      branch: "stack-a",
+      parent: "dev",
+      anchor: "dev-1",
+      pr: 4,
+    }),
+    stackLink({
+      branch: "stack-b",
+      parent: "stack-a",
+      anchor: "stack-a-1",
+      pr: 5,
+    }),
+    stackLink({
+      branch: "stack-c",
+      parent: forkStackC ? "stack-a" : "stack-b",
+      anchor: forkStackC ? "stack-a-1" : "stack-b-1",
+      pr: 3,
+    }),
+  ];
+  if (includeUnrelatedRoot) {
+    links.push(
+      stackLink({
+        branch: "other-root",
+        parent: "dev",
+        anchor: "dev-1",
+        pr: 9,
+      }),
+    );
+  }
 
   return {
     seen,
@@ -851,9 +902,11 @@ const makeLand = (
             Effect.succeed(
               parent === "dev" && branch === "stack-b"
                 ? ["b1"]
-                : parent === "stack-b" && branch === "stack-c"
+                : parent === "dev" && branch === "stack-c"
                   ? ["c1"]
-                  : [],
+                  : parent === "stack-b" && branch === "stack-c"
+                    ? ["c1"]
+                    : [],
             ),
           novel: (_parent: string, _branch: string, commits: ReadonlyArray<string>) =>
             Effect.succeed(commits),
@@ -914,26 +967,7 @@ const makeLand = (
         Store.memory(
           new StackState({
             version: 1,
-            links: [
-              stackLink({
-                branch: "stack-a",
-                parent: "dev",
-                anchor: "dev-1",
-                pr: 4,
-              }),
-              stackLink({
-                branch: "stack-b",
-                parent: "stack-a",
-                anchor: "stack-a-1",
-                pr: 5,
-              }),
-              stackLink({
-                branch: "stack-c",
-                parent: "stack-b",
-                anchor: "stack-b-1",
-                pr: 3,
-              }),
-            ],
+            links,
           }),
         ),
       ),
@@ -1140,7 +1174,10 @@ describe("StackGraph", () => {
 
     expect(graph.rootOf("stack-b")).toBe("stack-a");
     expect(graph.rank("stack-b")).toBe(2);
-    expect(graph.explicitChainFor("stack-b")).toEqual(["stack-a", "stack-b"]);
+    expect(graph.pathTo("stack-b")).toEqual(["stack-a", "stack-b"]);
+    expect(graph.pathTo("stack-c")).toEqual(["stack-a", "stack-c"]);
+    expect(graph.displayChainFor("stack-b")).toEqual(["stack-a", "stack-b"]);
+    expect(graph.displayChainFor("stack-c")).toEqual(["stack-a", "stack-c"]);
     expect(graph.wouldCreateCycle("stack-a", "stack-b")).toBe(true);
   });
 });
@@ -2789,6 +2826,52 @@ describe("Stack", () => {
     }).pipe(Effect.provide(test.layer));
   });
 
+  it.effect("links keep the root PR first when rendering a linear stack", () => {
+    const bodies = new Map<number, string>();
+    const pulls = [
+      pullRef({ number: 1, head: "stack-a", base: "dev", url: "u1", draft: false }),
+      pullRef({ number: 2, head: "stack-b", base: "stack-a", url: "u2", draft: false }),
+      pullRef({ number: 3, head: "stack-c", base: "stack-b", url: "u3", draft: false }),
+    ];
+    const staleRoot = `<!-- stack:links:start -->
+### [Stack](https://github.com/kitlangton/stack)
+
+1. #2
+2. #3
+3. **#1** 👈 current
+<!-- stack:links:end -->`;
+    const layer = stackTestLayer({
+      current: "stack-a",
+      refs: [ref("dev"), ref("stack-a"), ref("stack-b"), ref("stack-c")],
+      pulls,
+      state: new StackState({
+        version: 1,
+        links: [
+          stackLink({ branch: "stack-a", parent: "dev", anchor: "dev", pr: 1 }),
+          stackLink({ branch: "stack-b", parent: "stack-a", anchor: "a", pr: 2 }),
+          stackLink({ branch: "stack-c", parent: "stack-b", anchor: "b", pr: 3 }),
+        ],
+      }),
+      service: {
+        change: (number) => {
+          const pull = pulls.find((item) => item.number === number)!;
+          return Effect.succeed(metaFor(pull, number === 1 ? staleRoot : "body"));
+        },
+        body: (number, body) => Effect.sync(() => void bodies.set(number, body)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.links(true);
+
+      const body = bodies.get(1) ?? "";
+      expect(body).toContain("1. **#1** 👈 current");
+      expect(body).toContain("2. #2");
+      expect(body).toContain("3. #3");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("links use scannable GitLab MR references with titles", () => {
     const test = makeSync({
       provider: "gitlab",
@@ -3382,6 +3465,39 @@ describe("Stack", () => {
       expect(test.seen).toContain("auto 4");
       expect(test.seen).toContain("auto 5");
       expect(test.seen).not.toContain("auto 3");
+    }).pipe(Effect.provide(test.layer));
+  });
+
+  it.effect("land auto through stays on the selected stack when another root exists", () => {
+    const test = makeLand([], "stack-a", null, {}, true);
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const done = yield* stack.land(undefined, { auto: true, through: "5" });
+
+      expect(done).toContain("enable auto-merge #4 (stack-a)");
+      expect(done).toContain("enable auto-merge #5 (stack-b)");
+      expect(done).toContain("merged through: stack-b");
+      expect(done.join("\n")).not.toContain("multiple stack roots found");
+      expect(test.seen).toContain("auto 4");
+      expect(test.seen).toContain("auto 5");
+      expect(test.seen).not.toContain("auto 9");
+    }).pipe(Effect.provide(test.layer));
+  });
+
+  it.effect("land auto through follows the selected sibling branch", () => {
+    const test = makeLand([], "stack-a", null, {}, false, true);
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const done = yield* stack.land(undefined, { auto: true, through: "3" });
+
+      expect(done).toContain("enable auto-merge #4 (stack-a)");
+      expect(done).toContain("enable auto-merge #3 (stack-c)");
+      expect(done).toContain("merged through: stack-c");
+      expect(test.seen).toContain("auto 4");
+      expect(test.seen).toContain("auto 3");
+      expect(test.seen).not.toContain("auto 5");
     }).pipe(Effect.provide(test.layer));
   });
 


### PR DESCRIPTION
## Summary

Support mixed linear and parallel stack shapes without conflating merge path selection with PR stack-block rendering.

## Changes

- Split StackGraph chain APIs into `pathTo()` for `merge --auto --through` and `displayChainFor()` for PR body rendering.
- Keep bounded auto-merge on the selected root-to-target path, avoiding unrelated roots or sibling branches.
- Preserve root-first full stack blocks for linear PR stacks.
- Add regressions for sibling branches, unrelated roots, and root PR stack-block rendering.

## Tests

- `bun run typecheck`
- `bun run test`
- `bun run format:check`
- `bun run lint`
- `bun src/cli.ts --help`
- `bun src/cli.ts sync --help`
- `bun src/cli.ts merge --help`
