### PR TITLE
Push changed stack parents during sync

### DIFF
--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -786,6 +786,35 @@ ${note}`;
               return [...remotes];
             });
 
+            const branchNeedsPush = Effect.fn("Stack.repairStack.branchNeedsPush")(function* (
+              branch: string,
+              remote: string,
+            ) {
+              const localHead = heads.get(branch);
+              if (!localHead) return false;
+
+              const remoteRef = `${remote}/${branch}`;
+              const remoteHead = yield* git.head(remoteRef);
+              if (Option.isNone(remoteHead)) return true;
+              if (localHead === remoteHead.value) return false;
+
+              const base = yield* git.base(branch, remoteRef);
+              return Option.isSome(base) && base.value === remoteHead.value;
+            });
+
+            const publishRemotes = Effect.fn("Stack.repairStack.publishRemotes")(function* (
+              branch: string,
+              headRepository: string | null,
+              change: number | null,
+            ) {
+              const remotes = yield* pushRemotes(branch, headRepository, change);
+              const needed = new Array<string>();
+              for (const remote of remotes) {
+                if (yield* branchNeedsPush(branch, remote)) needed.push(remote);
+              }
+              return needed;
+            });
+
             const backups = refs
               .map((ref) => ref.name)
               .filter(
@@ -998,6 +1027,37 @@ ${note}`;
                 }
 
                 moved.add(link.branch);
+              } else if (pr && childBases.has(String(link.branch))) {
+                const targetRemotes = yield* publishRemotes(
+                  String(link.branch),
+                  headRepository,
+                  Number(pr.number),
+                );
+                if (targetRemotes.length > 0) {
+                  actions.push({
+                    _tag: "Push",
+                    mode,
+                    branch: String(link.branch),
+                    remotes: targetRemotes,
+                  });
+                  if (apply) {
+                    for (const remote of targetRemotes) {
+                      yield* step(
+                        StackResult.render(
+                          {
+                            _tag: "Push",
+                            mode,
+                            branch: String(link.branch),
+                            remotes: [remote],
+                          },
+                          reference,
+                          requestLabel,
+                        ),
+                      );
+                      yield* git.push(link.branch, remote);
+                    }
+                  }
+                }
               }
 
               const now = prs.get(link.branch) ?? null;

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -4242,6 +4242,42 @@ describe("Stack", () => {
     15_000,
   );
 
+  it.effect("sync pushes a changed parent before rebasing descendants", () =>
+    Effect.gen(function* () {
+      const scenario = yield* realStack({
+        current: "stack-b",
+        branches: [
+          {
+            name: "stack-b",
+            parent: "dev",
+            number: 2,
+            commits: [{ file: "b.txt", body: "b1\n", message: "b1" }],
+          },
+          {
+            name: "stack-c",
+            parent: "stack-b",
+            number: 3,
+            commits: [{ file: "c.txt", body: "c\n", message: "c" }],
+          },
+        ],
+      });
+
+      yield* commitFile(scenario.repo, "b2.txt", "b2\n", "b2");
+      const parent = yield* scenario.git(["rev-parse", "stack-b"]);
+      expect(yield* scenario.git(["rev-parse", "origin/stack-b"])).not.toBe(parent);
+
+      const items = yield* Effect.gen(function* () {
+        const stack = yield* Stack;
+        return yield* stack.sync({ apply: true });
+      }).pipe(Effect.provide(scenario.layer));
+
+      expect(items).toContain("└─ ✓ stack-b #2 pushed");
+      expect(items).toContain("   └─ ✓ stack-c #3 rebased onto stack-b");
+      expect(yield* scenario.git(["rev-parse", "origin/stack-b"])).toBe(parent);
+      expect(yield* scenario.git(["merge-base", "stack-c", "stack-b"])).toBe(parent);
+    }).pipe(Effect.provide(platform)),
+  );
+
   it.effect("sync rebases a deep stack when PR 2 is refactored", () =>
     Effect.gen(function* () {
       const scenario = yield* realStack({


### PR DESCRIPTION
## Summary

- Push stack parent branches that are locally ahead before rebasing descendant PR branches during `stack sync --apply`.
- Keep the PR scoped to the remaining behavior that complements the trunk config and worktree-aware repair work already on `main`.
- Add regression coverage for the stale parent remote case so parent and descendant PR heads publish the same propagated commits.

## Testing

- `bun run test tests/stack.test.ts -t "sync pushes a changed parent before rebasing descendants"`
- `bun run typecheck`
- `bun run test`
- `bun run format:check`
- `bun run lint`
- `bun src/cli.ts --help`
- `bun src/cli.ts sync --help`