### PR TITLE
feat(stack): configurable stack block heading link (stack.blockLink)

### DIFF
--- a/.changeset/block-link-config.md
+++ b/.changeset/block-link-config.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": minor
+---
+
+Add `git config stack.blockLink false` to render a plain `### Stack` heading in the stack block without the attribution link. The linked heading remains the default.

--- a/.changeset/mixed-stack-topology.md
+++ b/.changeset/mixed-stack-topology.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Support mixed linear and parallel stack shapes by separating merge path selection (`merge --auto --through`) from PR stack-block rendering, so auto-merge follows the selected branch and stack blocks no longer pull in an arbitrary sibling at a fork point.

--- a/.changeset/raw-remote-urls.md
+++ b/.changeset/raw-remote-urls.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Read raw configured remote URLs (`remote.origin.url`) instead of rewrite-expanded output, so repository and code-host detection stays correct under Git `insteadOf` rewrites and custom SSH host aliases.

--- a/.changeset/worktree-aware-repair.md
+++ b/.changeset/worktree-aware-repair.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": minor
+---
+
+Repair branches that are checked out in other worktrees by replaying them from their owning clean worktree instead of force-moving the ref. Sync and merge now fail before any mutation when a branch needing repair is checked out in a dirty worktree, and refuse to delete a local branch that is checked out elsewhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
 
 - Persist stack metadata in `.git/stack/state.json`.
 - Persist undo state in `.git/stack/undo.json`.
+- User preferences live in `git config stack.*` (read at startup in the CLI `live` layer), not in `state.json`. Current keys: `stack.codeHost`, `stack.trunks`, and `stack.blockLink` (default true; set false to render a plain `### Stack` heading without the attribution link).
 - Prefer `Context.Service`-based Effect services and test-first changes.
 - Use OpenCode-style service modules for deep seams: export `Interface`, `Service`, adapters like `layer`, `live`, or `memory`, and a namespace self-reexport such as `export * as CodeHost from "./CodeHost.ts"`; consumers import that named namespace directly from the module file.
 - Keep local Git behavior behind `Git` and pull/merge-request behavior behind `CodeHost`. Concrete backends live in `services/code-host/GitHub.ts` (via `gh`) and `services/code-host/GitLab.ts` (via `glab`), while their in-memory contract behavior is shared through `services/code-host/Memory.ts`; the CLI picks one backend at startup from `STACK_CODE_HOST`, `git config stack.codeHost`, or an unambiguous `origin` host. Stack orchestration depends on `CodeHost.Service` rather than shelling out to a host CLI directly.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ that use another trunk, such as `develop`, can configure the trunk list:
 git config stack.trunks dev,develop,main,master
 ```
 
+## Stack Block Heading
+
+Each stack block has a heading that links back to this project. To render a
+plain `### Stack` heading without the attribution link — for example in
+enterprise repos where external links trip compliance checks — set:
+
+```bash
+git config stack.blockLink false
+```
+
+The linked heading stays on by default. This is repo-local; use
+`git config --global stack.blockLink false` to apply it everywhere.
+
 ## Example Output
 
 ```text

--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -20,7 +20,9 @@ Install and authenticate the matching CLI before running `stack`. The
 For an enterprise host, run `git config stack.codeHost github` or `git config
 stack.codeHost gitlab`; `STACK_CODE_HOST` is available as a temporary override.
 Repos that use a trunk outside the default `dev`, `main`, and `master` set can
-configure trunks with `git config stack.trunks dev,develop,main,master`.
+configure trunks with `git config stack.trunks dev,develop,main,master`. To drop
+the attribution link from the stack block heading, run `git config
+stack.blockLink false` (it renders a plain `### Stack` heading).
 
 Keep ordinary editing and commits on plain `git`. Use `stack` only for stack
 intent, stack inspection, sync, merge, and undo workflows.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import pkg from "../package.json" with { type: "json" };
 import { BranchError, DirtyWorktreeError, ExecError, MergeBaseError } from "./domain/model.ts";
 import { renderStatus } from "./format.ts";
 import * as Proc from "./platform/proc.ts";
-import { parseTrunksConfig, StackConfig, trunks } from "./services/Config.ts";
+import { parseBlockLinkConfig, parseTrunksConfig, StackConfig, trunks } from "./services/Config.ts";
 import { CodeHost } from "./services/CodeHost.ts";
 import { CodeHostGitHub } from "./services/code-host/GitHub.ts";
 import { CodeHostGitLab } from "./services/code-host/GitLab.ts";
@@ -336,12 +336,20 @@ const live = (() => {
         [0, 1],
       );
       const configuredTrunks = parseTrunksConfig(configuredTrunksOut);
+      const blockLinkOut = yield* proc.exec(
+        root,
+        "git",
+        ["config", "--get", "stack.blockLink"],
+        [0, 1],
+      );
+      const blockLink = parseBlockLinkConfig(blockLinkOut);
 
       return StackConfig.layer({
         root,
         store: path.join(git, "stack", "state.json"),
         journal: path.join(git, "stack", "undo.json"),
         trunks: configuredTrunks.length > 0 ? configuredTrunks : trunks,
+        blockLink,
       });
     }),
   ).pipe(Layer.provideMerge(proc));

--- a/src/services/Config.ts
+++ b/src/services/Config.ts
@@ -8,6 +8,14 @@ export type Trunk = "dev" | "develop" | "main" | "master";
 
 export const trunks: ReadonlyArray<Exclude<Trunk, "develop">> = ["dev", "main", "master"];
 
+export const parseBlockLinkConfig = (value: string): boolean | undefined => {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "") return undefined;
+  if (["false", "no", "off", "0"].includes(normalized)) return false;
+  if (["true", "yes", "on", "1"].includes(normalized)) return true;
+  return undefined;
+};
+
 export const parseTrunksConfig = (value: string): ReadonlyArray<string> =>
   value
     .split(/[\s,]+/)
@@ -19,6 +27,7 @@ export interface StackConfigService {
   readonly store: string;
   readonly journal: string;
   readonly trunks: ReadonlyArray<BranchName>;
+  readonly blockLink: boolean;
   readonly codeHostConcurrency: number;
   readonly codeHostWaitIntervalMillis: number;
 }
@@ -31,6 +40,7 @@ export class StackConfig extends Context.Service<StackConfig, StackConfigService
     store?: string;
     journal?: string;
     trunks?: ReadonlyArray<string>;
+    blockLink?: boolean | undefined;
     codeHostConcurrency?: number;
     codeHostWaitIntervalMillis?: number;
   }) =>
@@ -43,6 +53,7 @@ export class StackConfig extends Context.Service<StackConfig, StackConfigService
           store: opts.store ?? path.join(opts.root, ".git", "stack", "state.json"),
           journal: opts.journal ?? path.join(opts.root, ".git", "stack", "undo.json"),
           trunks: (opts.trunks ?? trunks).map((name) => branchName(name)),
+          blockLink: opts.blockLink ?? true,
           codeHostConcurrency: opts.codeHostConcurrency ?? 4,
           codeHostWaitIntervalMillis: opts.codeHostWaitIntervalMillis ?? 5_000,
         });

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1409,6 +1409,7 @@ ${note}`;
                       reference,
                       showTitles: codeHost.provider === "gitlab",
                       completedTitles,
+                      blockLink: cfg.blockLink,
                     }),
                   );
                   if (next === meta.body) return null;

--- a/src/stackBlock.ts
+++ b/src/stackBlock.ts
@@ -2,7 +2,8 @@ import { PullMeta, PullRef } from "./domain/model.ts";
 
 const start = "<!-- stack:links:start -->";
 const end = "<!-- stack:links:end -->";
-const heading = "### [Stack](https://github.com/kitlangton/stack)";
+const linkedHeading = "### [Stack](https://github.com/kitlangton/stack)";
+const plainHeading = "### Stack";
 
 const inlineTitle = (value: string | null) => {
   const title = value?.replace(/\s+/g, " ").trim();
@@ -84,9 +85,11 @@ export const render = (opts: {
   readonly reference?: (number: number) => string;
   readonly showTitles?: boolean;
   readonly completedTitles?: ReadonlyMap<number, string>;
+  readonly blockLink?: boolean;
 }) => {
   const reference = opts.reference ?? ((number: number) => `#${number}`);
   const showTitles = opts.showTitles ?? false;
+  const heading = (opts.blockLink ?? true) ? linkedHeading : plainHeading;
   const prs = new Map(opts.pulls.map((pull) => [String(pull.head), pull]));
   const chain = opts.chain;
   const liveKeys = new Set(

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -23,7 +23,12 @@ import * as Proc from "../src/platform/proc.ts";
 import { RepairExecution } from "../src/repairExecution.ts";
 import * as StackBlock from "../src/stackBlock.ts";
 import * as StackGraph from "../src/stackGraph.ts";
-import { parseTrunksConfig, StackConfig, trunks } from "../src/services/Config.ts";
+import {
+  parseBlockLinkConfig,
+  parseTrunksConfig,
+  StackConfig,
+  trunks,
+} from "../src/services/Config.ts";
 import { CodeHost } from "../src/services/CodeHost.ts";
 import { CodeHostGitHub } from "../src/services/code-host/GitHub.ts";
 import { CodeHostGitLab } from "../src/services/code-host/GitLab.ts";
@@ -1223,6 +1228,20 @@ describe("StackConfig", () => {
       "main",
       "master",
     ]);
+  });
+
+  it("parses stack.blockLink truthy and falsy values", () => {
+    expect(parseBlockLinkConfig("false")).toBe(false);
+    expect(parseBlockLinkConfig("off")).toBe(false);
+    expect(parseBlockLinkConfig("0")).toBe(false);
+    expect(parseBlockLinkConfig("true")).toBe(true);
+    expect(parseBlockLinkConfig("yes")).toBe(true);
+  });
+
+  it("treats an unset or unrecognized stack.blockLink as default (undefined)", () => {
+    expect(parseBlockLinkConfig("")).toBeUndefined();
+    expect(parseBlockLinkConfig("  ")).toBeUndefined();
+    expect(parseBlockLinkConfig("maybe")).toBeUndefined();
   });
 });
 
@@ -4822,6 +4841,32 @@ describe("StackBlock", () => {
     expect(block).toContain("2. **#2** 👈 current");
     expect(block).toContain("3. #3");
     expect(block).not.toContain("Feature A");
+  });
+
+  it("renders the linked attribution heading by default", () => {
+    const block = StackBlock.render({
+      pulls,
+      metas: new Map(),
+      chain: ["feat/a", "feat/b", "feat/c"],
+      branch: "feat/b",
+      previous: "",
+    });
+    expect(block).toContain("### [Stack](https://github.com/kitlangton/stack)");
+  });
+
+  it("renders a plain heading without the attribution link when blockLink is false", () => {
+    const block = StackBlock.render({
+      pulls,
+      metas: new Map(),
+      chain: ["feat/a", "feat/b", "feat/c"],
+      branch: "feat/b",
+      previous: "",
+      blockLink: false,
+    });
+    expect(block).toContain("### Stack");
+    expect(block).not.toContain("[Stack]");
+    expect(block).not.toContain("https://github.com/kitlangton/stack");
+    expect(block).toContain("2. **#2** 👈 current");
   });
 
   it("renders GitLab MR references using the code host reference formatter", () => {


### PR DESCRIPTION
## Summary

Adds `git config stack.blockLink false` to render a plain `### Stack` heading in the stack block, without the attribution link back to this project. The linked heading remains the default, so this is non-breaking.

```bash
git config stack.blockLink false           # repo-local plain heading
git config --global stack.blockLink false  # everywhere
```

The key is read at startup in the CLI `live` layer, mirroring the existing `stack.codeHost` and `stack.trunks` reads. Truthy/falsy values (`true/false`, `yes/no`, `on/off`, `1/0`) are accepted; an unset or unrecognized value falls back to the linked default.

Closes #10 (which removed the link unconditionally) by making it configurable instead, and addresses the `stack.blockLink` portion of #17. The custom URL / title options from #17 are intentionally left as a possible follow-up.

## Changes

- `stackBlock.render` takes an optional `blockLink` (default true) and emits either the linked or plain heading.
- `StackConfig` carries `blockLink`; `parseBlockLinkConfig` normalizes the git config value.
- CLI reads `git config stack.blockLink` and threads it through to rendering.
- Docs: README, bundled `skills/stack/SKILL.md`, and `AGENTS.md` config-keys note.
- Changeset (minor). Also backfills missing changesets for already-merged #15, #19, and #18.

## Testing

- `bun run typecheck`
- `bun run test` (125 passing; adds unit tests for `parseBlockLinkConfig` and for linked/plain heading rendering)
- `bun run format:check`
- `bun run lint`
- Manual: confirmed `stack.blockLink` unset/`true` renders the linked heading and `false` renders `### Stack`.
