### PR TITLE
fix(gh): tolerate non-JSON warnings before gh pr view output

### DIFF
--- a/.changeset/tolerate-gh-warnings.md
+++ b/.changeset/tolerate-gh-warnings.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Tolerate non-JSON warnings (e.g. auth expiry notices) emitted before `gh pr view` JSON output. The decoder now extracts the JSON payload from stdout instead of requiring the entire output to be valid JSON.

--- a/src/services/code-host/GitHub.ts
+++ b/src/services/code-host/GitHub.ts
@@ -51,21 +51,31 @@ class PullListData extends Schema.Class<PullListData>("PullListData")({
 
 const PullListJson = Schema.Array(Schema.Array(PullListData));
 
+const extractJson = (out: string): string => {
+  const start = out.search(/[[{]/);
+  if (start === -1) return out;
+  const opener = out[start];
+  const closer = opener === "{" ? "}" : "]";
+  const end = out.lastIndexOf(closer);
+  if (end === -1 || end < start) return out;
+  return out.slice(start, end + 1);
+};
+
 const decodePullList = (args: ReadonlyArray<string>, out: string) =>
   Effect.try({
-    try: () => Schema.decodeUnknownSync(PullListJson)(JSON.parse(out)),
+    try: () => Schema.decodeUnknownSync(PullListJson)(JSON.parse(extractJson(out))),
     catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
   });
 
 const decodePullView = (args: ReadonlyArray<string>, out: string) =>
   Effect.try({
-    try: () => Schema.decodeUnknownSync(PullView)(JSON.parse(out)),
+    try: () => Schema.decodeUnknownSync(PullView)(JSON.parse(extractJson(out))),
     catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
   });
 
 const decodePullWatch = (args: ReadonlyArray<string>, out: string) =>
   Effect.try({
-    try: () => Schema.decodeUnknownSync(PullWatch)(JSON.parse(out)),
+    try: () => Schema.decodeUnknownSync(PullWatch)(JSON.parse(extractJson(out))),
     catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
   });
 

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1611,6 +1611,40 @@ describe("GitHub", () => {
     );
   });
 
+  it.effect("tolerates non-JSON warnings emitted before gh pr view output", () => {
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: () =>
+          Effect.sync(() =>
+            [
+              "warning: authentication token expires soon, run gh auth refresh",
+              JSON.stringify({
+                number: 1,
+                title: "one",
+                body: "body",
+                headRefName: "one",
+                headRepository: { nameWithOwner: "owner/project" },
+                baseRefName: "main",
+                url: "u1",
+                isDraft: false,
+                labels: [],
+              }),
+            ].join("\n"),
+          ),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const meta = yield* github.change(1);
+      expect(Number(meta.number)).toBe(1);
+      expect(meta.title).toBe("one");
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
   it.effect("resolves a created GitHub fork PR by its returned URL", () => {
     const calls: Array<ReadonlyArray<string>> = [];
     const proc = Layer.succeed(


### PR DESCRIPTION
## Summary

Fixes #12 — `gh pr view --json ...` can emit warning lines (e.g. auth expiry notices) to stdout before the JSON payload, causing `JSON.parse` to fail with "returned invalid JSON" even though the JSON itself is valid when run directly in a shell.

## Fix

Add `extractJson()` which finds the first `{` or `[` and its matching closer (`}` or `]`) in the output, stripping any leading/trailing non-JSON text before parsing. Applied to all three GitHub decoders (`decodePullList`, `decodePullView`, `decodePullWatch`).

## Test

Added a test simulating `gh` emitting an auth-warning line before the JSON payload, confirming the decoder successfully extracts and parses the JSON.

## Verification

- `bun run typecheck`
- `bun run test` (127 passing)
- `bun run format:check`
- `bun run lint`
