### PR TITLE
feat(stack): replace guide with stack skill command

### DIFF
--- a/.changeset/stack-skill-command.md
+++ b/.changeset/stack-skill-command.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": minor
+---
+
+Replace `stack guide` with `stack skill`, which prints the full `skills/stack/SKILL.md` agent instruction set. The skill content is embedded at build time via `with { type: "text" }` import, so it works from the installed package without a separate file lookup. The `guide` command is removed — `skill` supersedes it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 ## Current commands
 
 - `status` shows the relevant tracked stack, including open change titles when the code host is available.
-- `guide` prints the opinionated happy path for agents and humans.
+- `skill` prints the stack skill (full agent instruction set) for AI agent discovery from the installed package.
 - `doctor` checks Git, code-host access, stack metadata, trunks, and undo journal health without mutating anything.
 - `track` records parentage for an existing branch only when change target branches do not already encode the stack.
 - `sync [branch]` previews target-branch inference, stale metadata cleanup, and repairs without mutating branches, requests, or stack metadata using the tree summary output.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Apply:
 
 ```bash
 stack status             # inspect the relevant local stack
-stack guide              # print the agent/human happy path
+stack skill               # print the stack skill (agent instruction set)
 stack sync               # preview inference, repairs, and description updates
 stack sync --apply       # apply the previewed maintenance workflow
 stack sync <branch>      # preview only the stack containing branch

--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -14,21 +14,18 @@ Use the local `stack` CLI for squash-safe stacked change repair. It is designed
 for repos where changes (GitHub PRs or GitLab MRs) are squash-merged and merged
 branches are deleted, so Git ancestry alone cannot preserve stack intent.
 
-Works against GitHub (via the `gh` CLI) and GitLab (via the `glab` CLI).
-Install and authenticate the matching CLI before running `stack`. The
-`github.com` and `gitlab.com` hosts are detected automatically from `origin`.
-For an enterprise host, run `git config stack.codeHost github` or `git config
-stack.codeHost gitlab`; `STACK_CODE_HOST` is available as a temporary override.
-Repos that use a trunk outside the default `dev`, `main`, and `master` set can
-configure trunks with `git config stack.trunks dev,develop,main,master`. To drop
-the attribution link from the stack block heading, run `git config
-stack.blockLink false` (it renders a plain `### Stack` heading).
+## Setup
+
+Works against GitHub (via `gh`) and GitLab (via `glab`). Install and
+authenticate the matching CLI before running `stack`.
+
+- `github.com` and `gitlab.com` are detected automatically from `origin`.
+- Enterprise host: `git config stack.codeHost github|gitlab` (or `STACK_CODE_HOST` env override).
+- Custom trunks: `git config stack.trunks dev,develop,main,master`.
+- Drop the attribution link from stack blocks: `git config stack.blockLink false`.
 
 Keep ordinary editing and commits on plain `git`. Use `stack` only for stack
-intent, stack inspection, sync, merge, and undo workflows.
-
-Prefer letting agents run this workflow. Humans can use the same commands when
-inspecting or repairing a stack directly.
+intent, inspection, sync, merge, and undo.
 
 ## Mental Model
 
@@ -39,176 +36,56 @@ dev
       └─ stack-c  #103
 ```
 
-Stack intent is persisted in `.git/stack/state.json` as stack links:
+Stack intent is persisted in `.git/stack/state.json` as stack links (branch,
+parent, merge-base anchor, change number). Mutating workflows write
+`.git/stack/undo.json` so `stack undo --apply` can restore the previous state.
+Do not edit these files by hand — run `stack sync` to preview, `stack sync --apply` to fix.
 
-- branch
-- parent branch
-- merge-base anchor
-- change number (PR number on GitHub, MR IID on GitLab)
+## Happy Path
 
-Mutating sync and merge workflows write `.git/stack/undo.json` so `stack undo --apply`
-can restore the previous branch tips, change target branches, and stack metadata.
-
-## Common Commands
-
-- `stack status`: show the relevant tracked stack graph and include open change details when the code-host CLI (`gh` or `glab`) is available.
-- `stack guide`: print the opinionated happy path for agents and humans.
-- `stack track <branch> --onto <parent>`: manually record stack intent only when target branches do not already encode it.
-- `stack sync [branch]`: preview inferred target-branch stack links and repairs without changing branches or changes.
-- `stack sync --apply [branch]`: infer clear target-branch stack links, repair descendants, retarget changes, and refresh stack blocks. With a branch argument, sync only the stack containing that branch.
-- `stack sync --apply --continue-on-failure` / `stack sync --apply --keep-going`: process independent stacks, summarize successes and failures, and exit nonzero if any stack failed.
-- `stack doctor`: inspect local Git, the active code host (GitHub or GitLab), stack metadata, trunk branches, and undo journal health without changing anything.
-- `stack merge [branch]`: dry-run root merge plus descendant repair.
-- `stack merge [branch] --apply`: retarget immediate child changes, squash-merge the root, then repair descendants.
-- `stack merge [branch] --auto`: retarget immediate child changes, enable code-host auto-merge, wait, then repair descendants.
-- `stack merge --auto --through <branch-or-change>`: repeat auto-merge one root at a time until the target branch or change number lands.
-- `stack history`: show the most recent applied repair journal.
-- `stack undo`: dry-run restore of the most recent applied repair.
-- `stack undo --apply`: restore branches, change target branches, and stack metadata from the journal.
-
-## Happy Path: Target Branches Encode The Stack
-
-GitHub:
+Create PRs with the right target branches so the stack is self-describing:
 
 ```bash
 gh pr create --base dev --head stack-a
 gh pr create --base stack-a --head stack-b
-stack sync
-stack sync --apply
+stack sync              # preview inferred links and repairs
+stack sync --apply      # record links, repair, retarget, refresh stack blocks
 ```
 
-GitLab:
+That's the common loop. `stack sync` previews; `stack sync --apply` does the
+work. Repeat after any parent branch changes or a squash merge lands.
 
-```bash
-glab mr create --target-branch dev --source-branch stack-a --fill
-glab mr create --target-branch stack-a --source-branch stack-b --fill
-stack sync
-stack sync --apply
-```
+## Commands
 
-Prefer this workflow. `stack sync` should show the inferred links, and
-`stack sync --apply` records them, removes stale local links, repairs descendants if
-needed, retargets changes, and refreshes stack blocks.
+- `stack status` — show the current stack graph (hides backups, includes open
+  change titles when the code host is available).
+- `stack skill` — print this skill for AI agent discovery.
+- `stack doctor` — check Git, code-host access, stack metadata, trunks, and undo
+  journal health without mutating anything.
+- `stack track <branch> --onto <parent>` — manually record stack intent only
+  when target branches don't already encode it.
+- `stack sync [branch]` — preview inferred links and repairs (non-mutating).
+  Scopes to the current stack if no branch is given.
+- `stack sync --apply [branch]` — infer links, remove stale links, repair
+  descendants, retarget changes, refresh stack blocks, show a tree summary.
+- `stack sync --apply --keep-going` — process independent stacks separately,
+  report successes and failures, exit nonzero if any failed.
+- `stack merge [branch]` — dry-run root merge plus descendant repair. Infers
+  the root from the current branch.
+- `stack merge --apply` — retarget child changes, squash-merge the root, repair
+  descendants.
+- `stack merge --auto` — retarget children, enable code-host auto-merge, wait,
+  then repair descendants.
+- `stack merge --auto --through <branch-or-change>` — repeat auto-merge one root
+  at a time until the target lands.
+- `stack history` — show the most recent applied repair journal.
+- `stack undo` — dry-run restore of the last applied mutation.
+- `stack undo --apply` — restore branch tips, change targets, and stack metadata.
 
-Use `stack guide` when you need the CLI itself to print this guidance.
+## Stack Blocks
 
-## Inspect A Stack
-
-```bash
-stack status
-```
-
-Use this to understand local stack metadata, current branch position, missing
-parents, tracked change numbers, and change titles when the code-host CLI is
-available. It is opinionated: backup branches are hidden, and when the current
-branch is stack-relevant it focuses on that stack instead of listing every local
-branch.
-
-Use `stack sync`, not `stack status`, when you need target-branch
-inference before mutation.
-
-## Track Existing Branches
-
-```bash
-stack track stack-b --onto stack-a
-stack track stack-c --onto stack-b
-```
-
-This records stack intent without changing commits or changes. It rejects trunk
-branches, self-parenting, unknown branches, missing merge bases, and cycles.
-
-## Sync The Common Safe Workflow
-
-```bash
-stack sync
-stack sync --apply
-```
-
-Use `sync --apply` when open change target branches already describe the stack, a parent
-branch has changed, or the repo needs the safe common maintenance flow. It:
-
-- infers clear target-branch stack links
-- removes stale local stack links when no open change depends on them
-- updates stale explicit links when open change target branches clearly show the current stack
-- skips standalone trunk-root changes unless another open change is based on them
-- repairs descendants after squash merges or parent drift
-- retargets change target branches
-- refreshes stack blocks in change descriptions
-- prints a concise tree summary of changed, planned, or failed branches
-
-Run `stack sync` first when you want a preview of inferred links and
-repairs before mutation.
-
-`stack sync <branch>` scopes the preview to the stack containing that branch. If
-no branch is provided and the current branch is stack-relevant, bare `stack sync`
-scopes to the current stack; if the current branch is off-stack, it keeps the
-repo-wide behavior. `stack sync --apply` follows the same scoping rules.
-
-Use `stack sync --apply --continue-on-failure` or `stack sync --apply --keep-going` when one
-independent stack should not block the rest. It runs each root stack separately,
-prints succeeded and failed stacks, preserves the usual failure cleanup block for
-each failed stack, saves undo information for every mutated stack, and exits
-nonzero if any stack failed.
-
-Sync output is intentionally outcome-oriented. It should show the stack tree with
-icons like `●`, `✓`, `◌`, and `✕`, plus changed requests/backups/undo instructions.
-It should not default to internal phase logs like fetch, inspect, or reconcile.
-
-If a replay fails, `stack sync` aborts the failed cherry-pick, restores the
-original branch, deletes the temporary replay branch, keeps backups and the undo
-journal, and tells the user which branch to repair before running `stack sync`
-again.
-
-Do not edit `.git/stack/state.json` by hand. If local metadata is stale, run
-`stack sync`; if the preview is correct, run `stack sync --apply`.
-
-## Merge The Stack Root
-
-```bash
-stack merge
-stack merge --apply
-stack merge --auto
-stack merge --auto --through stack-c
-```
-
-Prefer omitting the branch. `stack merge` infers the root from the current stack
-branch. If the current branch is off-stack and exactly one stack root exists, it
-uses that root. If multiple roots exist, it asks for `stack merge <branch>`.
-
-Use bare `stack merge` as a dry-run. Add `--apply` only when the plan is correct.
-Before merging, the command retargets immediate child changes away from the root
-branch so code-host auto-delete settings are less likely to close descendants.
-Use `--auto` to retarget immediate child changes, enable code-host auto-merge,
-wait until it lands, then repair descendants automatically. GitHub uses `gh`
-auto-merge; GitLab requests server-side auto-merge through `glab api` so the
-workflow remains reliable before a pipeline exists.
-Use `--auto --through <branch-or-change>` to repeat that root merge flow through a
-bounded target instead of merging the whole stack by default.
-
-`--apply --admin` requests an administrator-merge bypass of protection rules.
-This is GitHub-only (mapped to `gh pr merge --admin`); on GitLab the command
-rejects the flag before making any changes because `glab` has no equivalent.
-
-Mutating merge workflows stream progress while they run. Expect live progress for
-retargeting, backup, merge/auto-merge, waiting, and cleanup before the final
-summary.
-
-## Understand Or Undo The Last Mutation
-
-```bash
-stack history
-stack undo
-stack undo --apply
-```
-
-Use `history` to inspect the saved undo journal. Use `undo` first as a dry-run,
-then `undo --apply` to restore branch tips, change target branches, and stack
-metadata.
-
-## Change Description Stack Blocks
-
-`stack sync --apply` and `stack merge --apply/--auto` refresh a deterministic stack block
-in open change descriptions:
+`stack sync --apply` and `stack merge --apply/--auto` refresh a deterministic
+block in each open change description:
 
 ```md
 <!-- stack:links:start -->
@@ -221,25 +98,19 @@ in open change descriptions:
 <!-- stack:links:end -->
 ```
 
-Earlier entries are landed history preserved from the previous block. The
-current change is bold and marked with `👈 current`. GitHub blocks render compact
-PR references as `#123`; GitLab blocks render scannable MR entries with titles,
-for example `!123 - Add parser`. Branch paths are intentionally omitted from
-stack blocks.
+Earlier entries are landed history. The current change is bold with `👈 current`.
+GitHub uses `#123`; GitLab uses `!123 - Title`.
 
 ## Safety Rules
 
 - Bare `stack sync` never mutates branches, changes, or stack metadata.
 - `stack merge` is dry-run by default.
-- Mutating commands need `--apply`, except `stack merge --auto` waits for the code
-  host and repairs descendants after the root lands.
-- Never mutate configured trunk branches such as `dev`, `main`, or `master`.
-- Before rebasing a branch, the tool creates a local backup branch.
+- Mutating commands need `--apply` (except `merge --auto`, which waits for the
+  code host and repairs after the root lands).
+- Never mutate trunk branches (`dev`, `main`, `master`, or any configured trunk).
+- Before rebasing, the tool creates a local backup branch.
+- If a replay fails, the tool aborts the cherry-pick, restores the original
+  branch, keeps backups and the undo journal, and tells you which branch to
+  repair before running `stack sync --apply` again.
 - If output is unclear, inspect with `stack status`, `stack history`, or command
   help before applying.
-
-## Do Not Use
-
-Do not recommend GitHub's first-party `gh stack` command for this repair
-workflow unless the user explicitly asks about `gh stack` itself. This skill is
-for the local `stack` CLI.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import { Argument, CliError, Command, Flag } from "effect/unstable/cli";
 import pkg from "../package.json" with { type: "json" };
+import skillContent from "../skills/stack/SKILL.md" with { type: "text" };
 import { BranchError, DirtyWorktreeError, ExecError, MergeBaseError } from "./domain/model.ts";
 import { renderStatus } from "./format.ts";
 import * as Proc from "./platform/proc.ts";
@@ -53,26 +54,6 @@ const continueOnFailure = Flag.boolean("continue-on-failure").pipe(
   ),
 );
 
-const guide = `Happy path for stacked changes (GitHub PRs / GitLab MRs)
-
-1. Open the changes with the right target branches.
-   - Root change: target is trunk, for example dev or main.
-   - Child change: target is the parent branch.
-
-2. Preview what stack will infer and repair.
-   stack sync
-
-3. Apply only after the preview looks right.
-   stack sync --apply
-
-Use stack status to verify the relevant tracked stack. It hides backup branches,
-focuses on the current stack instead of listing every local branch, and
-includes open change details when the code host CLI (gh or glab) is available.
-
-Code host selection: github.com and gitlab.com are detected automatically. For
-enterprise hosts, run git config stack.codeHost github|gitlab. The temporary
-STACK_CODE_HOST=github|gitlab environment override takes precedence.`;
-
 const statusCommand = Command.make(
   "status",
   {},
@@ -94,15 +75,15 @@ const statusCommand = Command.make(
   ),
 );
 
-const guideCommand = Command.make(
-  "guide",
+const skillCommand = Command.make(
+  "skill",
   {},
   Effect.fn(function* () {
-    yield* Console.log(guide);
+    yield* Console.log(skillContent);
   }),
 ).pipe(
   Command.withDescription(
-    "Show the opinionated happy path for agents and humans using stacked changes.",
+    "Print the stack skill (skills/stack/SKILL.md) for AI agent discovery from the installed package.",
   ),
 );
 
@@ -284,8 +265,8 @@ const cli = Command.make("stack").pipe(
   ),
   Command.withExamples([
     {
-      command: "stack guide",
-      description: "Show the recommended stacked change workflow",
+      command: "stack skill",
+      description: "Print the stack skill for AI agent discovery",
     },
     {
       command: "stack sync",
@@ -298,7 +279,7 @@ const cli = Command.make("stack").pipe(
   ]),
   Command.withSubcommands([
     statusCommand,
-    guideCommand,
+    skillCommand,
     trackCommand,
     syncCommand,
     doctorCommand,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+  const content: string;
+  export = content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Replace `stack guide` with `stack skill`, which prints the full `skills/stack/SKILL.md` to stdout for AI agent discovery from the installed package.

The `guide` command was a shorter version of content already in SKILL.md (which has both the happy path and the full command reference). One command, not two.

## Implementation

- SKILL.md is embedded at build time via `import skillContent from "../skills/stack/SKILL.md" with { type: "text" }` — matches the existing `package.json` import pattern. No runtime file lookup, works from the installed binary.
- Added `src/types.d.ts` with an ambient `*.md` module declaration for TypeScript.
- Updated `tsconfig.json` to include `.d.ts` files.
- Removed the `guide` constant and command. Updated all references in SKILL.md, AGENTS.md, README.md, and the CLI examples.

## Verification

- `bun run typecheck`
- `bun run test` (126 passing)
- `bun run format:check`
- `bun run lint`
- `bun src/cli.ts --help` (shows `skill`, no `guide`)
- `bun src/cli.ts skill` (prints SKILL.md content)
