### PR TITLE
fix(stack): harden merge cleanup and stranded repair

### DIFF
--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -109,6 +109,8 @@ GitHub uses `#123`; GitLab uses `!123 - Title`.
   code host and repairs after the root lands).
 - Never mutate trunk branches (`dev`, `main`, `master`, or any configured trunk).
 - Before rebasing, the tool creates a local backup branch.
+- Clean sibling worktrees can own branches being repaired or cleaned up; dirty
+  sibling owners fail before mutation.
 - If a replay fails, the tool aborts the cherry-pick, restores the original
   branch, keeps backups and the undo journal, and tells you which branch to
   repair before running `stack sync --apply` again.

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -45,6 +45,7 @@ export interface Interface {
     parent: string,
     commits: ReadonlyArray<string>,
   ) => Effect.Effect<void, ExecError>;
+  readonly release: (branch: string) => Effect.Effect<void, ExecError>;
   readonly backup: (branch: string, name: string) => Effect.Effect<void, ExecError>;
   readonly drop: (branch: string) => Effect.Effect<void, ExecError>;
   readonly restore: (branch: string, name: string) => Effect.Effect<void, ExecError>;
@@ -139,6 +140,19 @@ export const live = Layer.effect(
           ...worktree.dirty.map((line) => `  ${line}`),
           "",
           `Commit, stash, or clean that worktree before repairing ${branch}.`,
+        ].join("\n"),
+      );
+
+    const releaseDirtyError = (branch: string, worktree: Worktree) =>
+      new ExecError(
+        "git",
+        ["release", branch],
+        1,
+        [
+          `${branch} is checked out at ${worktree.path} with local changes:`,
+          ...worktree.dirty.map((line) => `  ${line}`),
+          "",
+          `Commit, stash, or clean that worktree before releasing ${branch}.`,
         ].join("\n"),
       );
 
@@ -269,6 +283,17 @@ export const live = Layer.effect(
     const backup = Effect.fn("Git.backup")((branch: string, name: string) =>
       run("git", ["branch", "-f", name, branch]).pipe(Effect.asVoid),
     );
+    const release = Effect.fn("Git.release")(function* (branch: string) {
+      const owner =
+        (yield* worktrees()).find(
+          (worktree) => worktree.branch === branch && worktree.path !== cfg.root,
+        ) ?? null;
+      if (!owner) return;
+      if (owner.dirty.length > 0) {
+        return yield* Effect.fail(releaseDirtyError(branch, owner));
+      }
+      return yield* runAt(owner.path, "git", ["checkout", "--detach", "HEAD"]).pipe(Effect.asVoid);
+    });
     const drop = Effect.fn("Git.drop")(function* (branch: string) {
       const owner =
         (yield* worktrees()).find(
@@ -311,6 +336,7 @@ export const live = Layer.effect(
       commits,
       novel,
       replay,
+      release,
       backup,
       drop,
       restore,
@@ -350,6 +376,7 @@ export const test = (opts: {
       commits: () => Effect.succeed([]),
       novel: (_parent, _branch, commits) => Effect.succeed(commits),
       replay: () => Effect.void,
+      release: () => Effect.void,
       backup: () => Effect.void,
       drop: () => Effect.void,
       restore: () => Effect.void,

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1636,6 +1636,11 @@ ${note}`;
             const stamp = yield* timestamp();
             const name = `backup/landed-${stamp}-${target}`;
             const hasLocalTarget = refs.some((item) => item.name === target);
+            const targetOwner = hasLocalTarget
+              ? ((yield* git.worktrees()).find(
+                  (worktree) => worktree.branch === target && worktree.path !== cfg.root,
+                ) ?? null)
+              : null;
             const next = scopedState.links.find((item) => item.parent === target)?.branch ?? null;
             const landed = new Set([reference(Number(pr.number)), String(target)]);
             const preRetargets = (yield* Effect.forEach(
@@ -1741,11 +1746,12 @@ ${note}`;
               { apply: false },
             );
             if (active) {
-              yield* ensureRepairableWorktrees(
-                plannedRepair.actions.flatMap((item) =>
+              yield* ensureRepairableWorktrees([
+                ...(targetOwner ? [target] : []),
+                ...plannedRepair.actions.flatMap((item) =>
                   item._tag === "Rebase" ? [String(item.branch)] : [],
                 ),
-              );
+              ]);
             }
             const actions = [
               ...(current === target ? [`${active ? "" : "would "}switch to ${root}`] : []),
@@ -1820,6 +1826,10 @@ ${note}`;
               }
               yield* beginPostMergeRepair();
               if (hasLocalTarget) {
+                if (targetOwner) {
+                  yield* step(`release ${target} worktree`);
+                  yield* git.release(target);
+                }
                 yield* step(`drop local ${target}`);
                 yield* git.drop(target);
               }

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -786,6 +786,11 @@ ${note}`;
                   name.startsWith("backup/landed-") || name.startsWith("backup/stack-sync-"),
               )
               .sort();
+            const landedBackupHeads = new Set(
+              refs
+                .filter((ref) => ref.name.startsWith("backup/landed-"))
+                .map((ref) => String(ref.head)),
+            );
             for (const name of backups) {
               for (const link of state.links) {
                 if (name.endsWith(`-${link.branch}`)) prior.set(String(link.branch), name);
@@ -930,7 +935,11 @@ ${note}`;
                   headRepository,
                   pr ? Number(pr.number) : link.pr ? Number(link.pr) : null,
                 );
-                const anchor = replayAnchors.get(String(link.branch));
+                const landedAnchor =
+                  trunk(parent) && landedBackupHeads.has(String(link.anchor))
+                    ? String(link.anchor)
+                    : null;
+                const anchor = replayAnchors.get(String(link.branch)) ?? landedAnchor;
                 const baseRef = anchor ? Option.some(anchor) : yield* git.base(link.branch, from);
                 const commitsToReplay = Option.isSome(baseRef)
                   ? yield* Effect.gen(function* () {

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -3081,6 +3081,46 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("sync uses persisted child anchor after merge state was stranded", () => {
+    const seen: Array<string> = [];
+    const pulls = [pr(2, "child", "dev")];
+    const layer = stackTestLayer({
+      current: "child",
+      refs: [
+        ref("dev", "dev-squash"),
+        ref("child", "child-head"),
+        ref("backup/landed-1700000000000-parent", "parent-tip"),
+      ],
+      pulls,
+      bases: bases(["child", "dev", "dev-old"]),
+      state: stackState([
+        stackLink({ branch: "child", parent: "dev", anchor: "parent-tip", pr: 2 }),
+      ]),
+      service: {
+        commits: (from: string, branch: string) =>
+          Effect.succeed(
+            branch === "child" && from === "parent-tip"
+              ? ["child-only"]
+              : branch === "child" && from === "dev-old"
+                ? ["parent-1", "parent-2", "child-only"]
+                : [],
+          ),
+        novel: (_parent: string, _branch: string, commits: ReadonlyArray<string>) =>
+          Effect.succeed(commits),
+        replay: (branch: string, parent: string, commits: ReadonlyArray<string>) =>
+          Effect.sync(() => seen.push(`rebase ${branch} ${parent} ${commits.join(",")}`)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.sync({ apply: true });
+
+      expect(seen).toContain("rebase child origin/dev child-only");
+      expect(seen).not.toContain("rebase child origin/dev parent-1,parent-2,child-only");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("undo restores the last applied mutation", () => {
     const test = makeSync();
 

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -90,6 +90,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     commits: () => Effect.succeed([]),
     novel: (_parent, _branch, commits) => Effect.succeed(commits),
     replay: () => Effect.void,
+    release: () => Effect.void,
     backup: () => Effect.void,
     drop: () => Effect.void,
     restore: () => Effect.void,
@@ -830,7 +831,7 @@ const makeLand = (
   dirty: ReadonlyArray<string> = [],
   currentBranch = "stack-a",
   progress: Array<Progress.ProgressEvent> | null = null,
-  codeHost: Partial<CodeHost.Interface> = {},
+  codeHost: Partial<Git.Interface & CodeHost.Interface> = {},
   includeUnrelatedRoot = false,
   forkStackC = false,
 ) => {
@@ -993,6 +994,7 @@ const makeLand = (
               refs.set(branch, branchRef({ name: branch, head: `${branch}-2` }));
               bases.set(`${branch}:${parent}`, refs.get(parent)?.head ?? "");
             }),
+          release: (branch: string) => Effect.sync(() => void seen.push(`release ${branch}`)),
           backup: (branch: string, name: string) =>
             Effect.sync(() => void seen.push(`backup ${branch} ${name}`)),
           drop: (branch: string) => Effect.sync(() => void seen.push(`drop ${branch}`)),
@@ -1405,6 +1407,75 @@ describe("Git", () => {
         expect(error.stderr).toContain("stack-b-worktree");
         expect(error.stderr).toContain("?? dirty.txt");
         expect(yield* shell(repo, "git", ["rev-parse", "stack-b"])).toBe(original);
+      }).pipe(Effect.provide(platform)),
+    15_000,
+  );
+
+  it.effect(
+    "release detaches a clean owning worktree",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const repo = join(root, "repo");
+        const sibling = join(root, "stack-b-worktree");
+
+        yield* mkdirp(repo);
+        yield* shell(repo, "git", ["init", "-b", "dev"]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* commitFile(repo, "base.txt", "base\n", "base");
+
+        yield* shell(repo, "git", ["checkout", "-b", "stack-b"]);
+        yield* commitFile(repo, "b.txt", "b1\n", "b1");
+        const stackBTip = yield* shell(repo, "git", ["rev-parse", "stack-b"]);
+        yield* shell(repo, "git", ["checkout", "dev"]);
+        yield* shell(repo, "git", ["worktree", "add", sibling, "stack-b"]);
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["dev"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+
+        yield* Effect.gen(function* () {
+          const git = yield* Git.Service;
+          yield* git.release("stack-b");
+        }).pipe(Effect.provide(Git.live.pipe(Layer.provide(cfgLayer))));
+
+        expect(yield* shell(sibling, "git", ["branch", "--show-current"])).toBe("");
+        expect(yield* shell(sibling, "git", ["rev-parse", "HEAD"])).toBe(stackBTip);
+        expect(yield* shell(repo, "git", ["rev-parse", "--verify", "stack-b"])).toBe(stackBTip);
+      }).pipe(Effect.provide(platform)),
+    15_000,
+  );
+
+  it.effect(
+    "release no-ops when branch is not checked out elsewhere",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const repo = join(root, "repo");
+
+        yield* mkdirp(repo);
+        yield* shell(repo, "git", ["init", "-b", "dev"]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* commitFile(repo, "base.txt", "base\n", "base");
+
+        yield* shell(repo, "git", ["checkout", "-b", "stack-b"]);
+        yield* commitFile(repo, "b.txt", "b1\n", "b1");
+        const stackBTip = yield* shell(repo, "git", ["rev-parse", "stack-b"]);
+        yield* shell(repo, "git", ["checkout", "dev"]);
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["dev"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+
+        yield* Effect.gen(function* () {
+          const git = yield* Git.Service;
+          yield* git.release("stack-b");
+        }).pipe(Effect.provide(Git.live.pipe(Layer.provide(cfgLayer))));
+
+        expect(yield* shell(repo, "git", ["branch", "--show-current"])).toBe("dev");
+        expect(yield* shell(repo, "git", ["rev-parse", "--verify", "stack-b"])).toBe(stackBTip);
       }).pipe(Effect.provide(platform)),
     15_000,
   );
@@ -3716,6 +3787,56 @@ describe("Stack", () => {
     }).pipe(Effect.provide(test.layer));
   });
 
+  it.effect("land apply releases a clean checked-out target before deleting it", () => {
+    const test = makeLand([], "dev", null, {
+      worktrees: () =>
+        Effect.succeed([
+          {
+            path: "/tmp/stack-a-worktree",
+            head: "stack-a-1",
+            branch: "stack-a",
+            dirty: [],
+          },
+        ]),
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.land("stack-a", { apply: true });
+
+      const release = test.seen.indexOf("release stack-a");
+      const drop = test.seen.indexOf("drop stack-a");
+      expect(release).toBeGreaterThan(-1);
+      expect(drop).toBeGreaterThan(release);
+      expect(test.seen.indexOf("merge 4")).toBeLessThan(release);
+    }).pipe(Effect.provide(test.layer));
+  });
+
+  it.effect("land auto releases a clean checked-out target before deleting it", () => {
+    const test = makeLand([], "dev", null, {
+      worktrees: () =>
+        Effect.succeed([
+          {
+            path: "/tmp/stack-a-worktree",
+            head: "stack-a-1",
+            branch: "stack-a",
+            dirty: [],
+          },
+        ]),
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.land("stack-a", { auto: true });
+
+      const release = test.seen.indexOf("release stack-a");
+      const drop = test.seen.indexOf("drop stack-a");
+      expect(release).toBeGreaterThan(-1);
+      expect(drop).toBeGreaterThan(release);
+      expect(test.seen.indexOf("wait 4 merged")).toBeLessThan(release);
+    }).pipe(Effect.provide(test.layer));
+  });
+
   it.effect("land auto can merge through a target PR", () => {
     const test = makeLand();
 
@@ -4457,6 +4578,56 @@ describe("Stack", () => {
         ),
       );
       expect(err).toContain("worktree is dirty");
+      expect(test.seen).toEqual([]);
+    }).pipe(Effect.provide(test.layer));
+  });
+
+  it.effect("land apply refuses a dirty target worktree before merging the root", () => {
+    const test = makeLand([], "dev", null, {
+      worktrees: () =>
+        Effect.succeed([
+          {
+            path: "/tmp/stack-a-worktree",
+            head: "stack-a-1",
+            branch: "stack-a",
+            dirty: ["?? dirty.txt"],
+          },
+        ]),
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const error = yield* Effect.flip(stack.land("stack-a", { apply: true }));
+
+      expect(error).toBeInstanceOf(StackOperationError);
+      expect(error.message).toContain("Cannot repair checked-out dirty worktree branches");
+      expect(error.message).toContain("stack-a -> /tmp/stack-a-worktree");
+      expect(error.message).toContain("?? dirty.txt");
+      expect(test.seen).toEqual([]);
+    }).pipe(Effect.provide(test.layer));
+  });
+
+  it.effect("land auto refuses a dirty target worktree before merging the root", () => {
+    const test = makeLand([], "dev", null, {
+      worktrees: () =>
+        Effect.succeed([
+          {
+            path: "/tmp/stack-a-worktree",
+            head: "stack-a-1",
+            branch: "stack-a",
+            dirty: ["?? dirty.txt"],
+          },
+        ]),
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const error = yield* Effect.flip(stack.land("stack-a", { auto: true }));
+
+      expect(error).toBeInstanceOf(StackOperationError);
+      expect(error.message).toContain("Cannot repair checked-out dirty worktree branches");
+      expect(error.message).toContain("stack-a -> /tmp/stack-a-worktree");
+      expect(error.message).toContain("?? dirty.txt");
       expect(test.seen).toEqual([]);
     }).pipe(Effect.provide(test.layer));
   });


### PR DESCRIPTION
## Summary

Fix two stack merge repair failure modes: landed branches checked out in clean sibling worktrees are released before cleanup, and stranded squash-merge descendants can recover their persisted replay anchor.

## Changes

- Add `Git.release(branch)` cleanup and dirty-owner preflight for checked-out landed branches.
- Use persisted `backup/landed-*` anchors when repairing already trunk-parented descendants.
- Cover both flows with focused regression tests.

## Tests

- `bun run test`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run package:smoke`
