### PR TITLE
chore: backfill changesets for #30 and #31

### DIFF
--- a/.changeset/recover-stranded-anchors.md
+++ b/.changeset/recover-stranded-anchors.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Recover stranded squash repair anchors: if `stack merge` persists state but aborts before descendant repair, a later `stack sync --apply` now uses the persisted anchor when it matches a `backup/landed-*` ref, so stranded descendants replay only their own commits instead of re-replaying the already-squashed parent.

--- a/.changeset/release-landed-worktrees.md
+++ b/.changeset/release-landed-worktrees.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Detach clean sibling worktrees that own a landed branch before deleting it during `stack merge --apply` and `stack merge --auto` cleanup. Fails before hosted mutation when the target worktree is dirty.


### PR DESCRIPTION
Backfill missing changesets for the merged merge-cleanup and stranded-anchor fixes.