### PR TITLE
feat(stack): atomic state writes and cherry-pick conflict path surfacing

### DIFF
--- a/.changeset/durability-conflict-surfacing.md
+++ b/.changeset/durability-conflict-surfacing.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Write `state.json` and `undo.json` atomically via tmp+rename so a crash mid-write cannot corrupt stack metadata. When a cherry-pick fails during repair, surface the conflicting file paths before aborting so the user knows which files need attention. Corrupt state files now include a recovery hint in the error message.

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -207,6 +207,35 @@ export class StackOperationError extends Schema.TaggedErrorClass<StackOperationE
   }
 }
 
+export class ReplayConflictError extends Schema.TaggedErrorClass<ReplayConflictError>()(
+  "ReplayConflictError",
+  {
+    branch: Schema.String,
+    parent: Schema.String,
+    paths: Schema.Array(Schema.String),
+    stderr: Schema.String,
+    message: Schema.String,
+  },
+) {
+  constructor(
+    readonly branch: string,
+    readonly parent: string,
+    readonly paths: ReadonlyArray<string>,
+    readonly stderr: string,
+  ) {
+    super({
+      branch,
+      parent,
+      paths: Array.from(paths),
+      stderr,
+      message:
+        paths.length > 0
+          ? `cherry-pick of ${branch} onto ${parent} failed in: ${paths.join(", ")}`
+          : `cherry-pick of ${branch} onto ${parent} failed`,
+    });
+  }
+}
+
 export class CodeHostDecodeError extends Schema.TaggedErrorClass<CodeHostDecodeError>()(
   "CodeHostDecodeError",
   {
@@ -276,7 +305,8 @@ export type StackError =
   | BranchError
   | MergeBaseError
   | DirtyWorktreeError
-  | StackOperationError;
+  | StackOperationError
+  | ReplayConflictError;
 
 export const stackState = (links: ReadonlyArray<StackLink>) =>
   new StackState({ version, links: Array.from(links) });

--- a/src/repairExecution.ts
+++ b/src/repairExecution.ts
@@ -1,5 +1,5 @@
 import * as Effect from "effect/Effect";
-import type { ExecError, StackError } from "./domain/model.ts";
+import type { ExecError, ReplayConflictError, StackError } from "./domain/model.ts";
 import type { RebaseBranchPlan, RetargetPullPlan } from "./repairPlan.ts";
 import type { Interface as Git } from "./services/Git.ts";
 import * as StackResult from "./stackResult.ts";
@@ -11,7 +11,7 @@ interface Dependencies {
 
 export interface ApplyRebaseBranchDependencies extends Dependencies {
   readonly git: Pick<Git, "backup" | "replay" | "push">;
-  readonly onReplayFailure: (error: ExecError) => StackError;
+  readonly onReplayFailure: (error: ExecError | ReplayConflictError) => StackError;
 }
 
 export const applyRebaseBranch = Effect.fn("RepairExecution.applyRebaseBranch")(function* (

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -3,7 +3,7 @@ import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import { BranchRef, branchRef, ExecError } from "../domain/model.ts";
+import { BranchRef, branchRef, ExecError, ReplayConflictError } from "../domain/model.ts";
 import * as Proc from "../platform/proc.ts";
 import { StackConfig } from "./Config.ts";
 
@@ -44,7 +44,8 @@ export interface Interface {
     branch: string,
     parent: string,
     commits: ReadonlyArray<string>,
-  ) => Effect.Effect<void, ExecError>;
+  ) => Effect.Effect<void, ExecError | ReplayConflictError>;
+  readonly unmergedPaths: () => Effect.Effect<ReadonlyArray<string>, ExecError>;
   readonly release: (branch: string) => Effect.Effect<void, ExecError>;
   readonly backup: (branch: string, name: string) => Effect.Effect<void, ExecError>;
   readonly drop: (branch: string) => Effect.Effect<void, ExecError>;
@@ -235,6 +236,11 @@ export const live = Layer.effect(
         }),
       );
     });
+    const unmergedPaths = Effect.fn("Git.unmergedPaths")(() =>
+      run("git", ["diff", "--name-only", "--diff-filter=U"], [0, 1]).pipe(
+        Effect.map((out) => out.split("\n").filter(Boolean)),
+      ),
+    );
     const replay = Effect.fn("Git.replay")(function* (
       branch: string,
       parent: string,
@@ -266,6 +272,16 @@ export const live = Layer.effect(
         if (commits.length > 0) {
           yield* runAt(root, "git", ["cherry-pick", "--empty=drop", ...commits]).pipe(
             Effect.asVoid,
+            Effect.catchTag("ExecError", (err) =>
+              Effect.gen(function* () {
+                const paths = yield* unmergedPaths().pipe(
+                  Effect.catch(() => Effect.succeed([] as ReadonlyArray<string>)),
+                );
+                return yield* Effect.fail(
+                  new ReplayConflictError(branch, parent, paths, err.stderr),
+                );
+              }),
+            ),
           );
         }
         if (owner) {
@@ -336,6 +352,7 @@ export const live = Layer.effect(
       commits,
       novel,
       replay,
+      unmergedPaths,
       release,
       backup,
       drop,
@@ -376,6 +393,7 @@ export const test = (opts: {
       commits: () => Effect.succeed([]),
       novel: (_parent, _branch, commits) => Effect.succeed(commits),
       replay: () => Effect.void,
+      unmergedPaths: () => Effect.succeed([] as ReadonlyArray<string>),
       release: () => Effect.void,
       backup: () => Effect.void,
       drop: () => Effect.void,

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -158,6 +158,9 @@ ${note}`;
             "",
             "Failed:",
             `  ${rebase.branch} could not be replayed onto ${rebase.parent}`,
+            ...(err._tag === "ReplayConflictError" && err.paths.length > 0
+              ? ["", "Conflicting paths:", ...err.paths.map((p) => `  ${p}`)]
+              : []),
             "",
             "Cleaned up:",
             `  backup created: ${rebase.backup}`,
@@ -172,7 +175,11 @@ ${note}`;
             "",
             "Git error:",
             err instanceof Error ? `  ${err.message}` : `  ${String(err)}`,
-            err._tag === "ExecError" && err.stderr ? `  ${err.stderr}` : null,
+            err._tag === "ExecError" && err.stderr
+              ? `  ${err.stderr}`
+              : err._tag === "ReplayConflictError" && err.stderr
+                ? `  ${err.stderr}`
+                : null,
           ]
             .filter((line): line is string => line !== null)
             .join("\n"),

--- a/src/services/Store.ts
+++ b/src/services/Store.ts
@@ -39,7 +39,12 @@ export class Store extends Context.Service<Store, StoreService>()("@stack/Store"
 
           return yield* Effect.try({
             try: () => parse(raw),
-            catch: (err) => new StateError(file, "decode", String(err)),
+            catch: (err) =>
+              new StateError(
+                file,
+                "decode",
+                `${err instanceof Error ? err.message : String(err)}\n\nThe file may be corrupt or from a future version. To recover, delete ${file} and rerun.`,
+              ),
           });
         });
 
@@ -49,9 +54,16 @@ export class Store extends Context.Service<Store, StoreService>()("@stack/Store"
             .makeDirectory(path.dirname(file), { recursive: true })
             .pipe(Effect.mapError((err) => new StateError(file, "mkdir", String(err))));
 
+          const tmp = `${file}.tmp`;
+          const body = `${JSON.stringify(encode(value), null, 2)}\n`;
+
           yield* fs
-            .writeFileString(file, `${JSON.stringify(encode(value), null, 2)}\n`)
-            .pipe(Effect.mapError((err) => new StateError(file, "write", String(err))));
+            .writeFileString(tmp, body)
+            .pipe(Effect.mapError((err) => new StateError(tmp, "write", String(err))));
+
+          yield* fs
+            .rename(tmp, file)
+            .pipe(Effect.mapError((err) => new StateError(file, "rename", String(err))));
         });
 
       const read = Effect.fn("Store.read")(() =>

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -13,6 +13,7 @@ import {
   PullLabel,
   pullMeta,
   pullRef,
+  ReplayConflictError,
   stackLink,
   StackOperationError,
   stackState,
@@ -90,6 +91,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     commits: () => Effect.succeed([]),
     novel: (_parent, _branch, commits) => Effect.succeed(commits),
     replay: () => Effect.void,
+    unmergedPaths: () => Effect.succeed([] as ReadonlyArray<string>),
     release: () => Effect.void,
     backup: () => Effect.void,
     drop: () => Effect.void,
@@ -1316,7 +1318,7 @@ describe("Git", () => {
 
       const error = yield* Effect.flip(git.replay("stack-b", "dev", ["b1"]));
 
-      expect(error).toBeInstanceOf(ExecError);
+      expect(error).toBeInstanceOf(ReplayConflictError);
       const temp = calls[2]?.[3];
       expect(temp).toBe("stack/replay-1700000000000-stack-b");
       expect(calls).toEqual([
@@ -1324,6 +1326,7 @@ describe("Git", () => {
         ["git", "branch", "--show-current"],
         ["git", "checkout", "-B", temp, "dev"],
         ["git", "cherry-pick", "--empty=drop", "b1"],
+        ["git", "diff", "--name-only", "--diff-filter=U"],
         ["git", "cherry-pick", "--abort"],
         ["git", "checkout", "stack-c"],
         ["git", "branch", "-D", temp],


### PR DESCRIPTION
Extracted from the worktree-stack-hardening branch.

## Changes

1. **Atomic state writes** — `state.json` and `undo.json` are now written to a `.tmp` file then renamed, so a crash mid-write cannot corrupt stack metadata. Corrupt state files now include a recovery hint in the error message.

2. **Cherry-pick conflict surfacing** — when a replay fails, `git diff --name-only --diff-filter=U` runs before the abort to collect the conflicting paths. The error output now includes a "Conflicting paths" section so the user knows exactly which files need attention.

## Verification

- `bun run typecheck`
- `bun run test` (134 passing)
- `bun run format:check`
- `bun run lint`
