### PR TITLE
feat(stack): keep child pull requests draft

### DIFF
--- a/.changeset/quiet-drafts-ready.md
+++ b/.changeset/quiet-drafts-ready.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": minor
+---
+
+Create GitHub stack descendants as draft pull requests and mark them ready only after they become repaired trunk-targeting roots.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@
 - `sync` with no branch scopes to the current stack when the current branch is stack-relevant; when off-stack, it keeps the repo-wide behavior.
 - `sync --apply --continue-on-failure` / `sync --apply --keep-going` processes independent stacks, reports succeeded and failed stacks, preserves per-stack cleanup output, and exits nonzero if any stack failed.
 - `sync` should not auto-track standalone trunk-root requests; infer a trunk-root request only when another open request is based on it.
-- `merge` merges the oldest branch in a stack and immediately repairs descendants; when no branch is given, it infers the root from the current branch. It retargets immediate child requests before merge to preserve open work in auto-delete repos.
+- On GitHub, replacement requests targeting another stack branch are drafts; requests targeting a configured trunk are ready.
+- `merge` merges the oldest branch in a stack and immediately repairs descendants; when no branch is given, it infers the root from the current branch. It retargets immediate child requests before merge to preserve open work in auto-delete repos, then marks each repaired GitHub child ready after it becomes a root.
 - `merge --auto` retargets immediate child requests, enables code-host auto-merge, waits for merge, then repairs descendants.
 - `merge --auto --through <branch-or-change>` repeats root auto-merge and descendant repair until the target branch or request has landed.
 - `history` explains the most recent applied mutation from the undo journal.
@@ -41,6 +42,7 @@
 - Prefer `Context.Service`-based Effect services and test-first changes.
 - Use OpenCode-style service modules for deep seams: export `Interface`, `Service`, adapters like `layer`, `live`, or `memory`, and a namespace self-reexport such as `export * as CodeHost from "./CodeHost.ts"`; consumers import that named namespace directly from the module file.
 - Keep local Git behavior behind `Git` and pull/merge-request behavior behind `CodeHost`. Concrete backends live in `services/code-host/GitHub.ts` (via `gh`) and `services/code-host/GitLab.ts` (via `glab`), while their in-memory contract behavior is shared through `services/code-host/Memory.ts`; the CLI picks one backend at startup from `STACK_CODE_HOST`, `git config stack.codeHost`, or an unambiguous `origin` host. Stack orchestration depends on `CodeHost.Service` rather than shelling out to a host CLI directly.
+- Keep draft-state behavior capability-gated in `CodeHost`; GitHub supports it and GitLab currently does not.
 - Check the local Effect source tree when available before changing Effect APIs or versions.
 - Prefer `effect/Path`, `effect/FileSystem`, and `effect/unstable/process` instead of Node/Bun built-ins in app code.
 - Keep logic literal and debuggable over clever abstractions.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ glab auth login    # GitLab
 
 1. Create stacked changes using normal git branches.
 2. Open the root PR/MR against trunk, for example `main` or `dev`.
-3. Open each child PR/MR against its parent branch.
+3. On GitHub, open each child PR as a draft against its parent branch. GitLab
+   draft state is not managed.
 4. Preview the stack:
 
 ```bash
@@ -70,6 +71,8 @@ then repair descendants automatically after the root lands.
 - Records stack intent in `.git/stack/state.json`.
 - Repairs descendants after parent branches move or land.
 - Retargets PRs/MRs when needed.
+- Creates missing GitHub child PRs as drafts and marks them ready only after
+  they become trunk-targeting roots.
 - Refreshes stack blocks in descriptions.
 - Saves `.git/stack/undo.json` before mutations.
 
@@ -90,6 +93,10 @@ Provider selection is automatic for public hosts:
 
 - `github.com` uses `gh`.
 - `gitlab.com` uses `glab`.
+
+GitHub draft state follows stack position: trunk-targeting PRs are ready and
+child PRs are draft. `stack merge` promotes the next root only after descendant
+repair and pushes finish. GitLab draft state remains unchanged.
 
 For enterprise hosts, configure the repo once:
 

--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -27,6 +27,11 @@ authenticate the matching CLI before running `stack`.
 Keep ordinary editing and commits on plain `git`. Use `stack` only for stack
 intent, inspection, sync, merge, and undo.
 
+On GitHub, keep only PRs that target a configured trunk ready for review. Create
+every child PR as a draft. When repair recreates a missing PR, `stack` applies
+the same rule; after a root lands and repair finishes, it marks the new root
+ready. GitLab draft state is not managed.
+
 ## Mental Model
 
 ```text
@@ -47,13 +52,17 @@ Create PRs with the right target branches so the stack is self-describing:
 
 ```bash
 gh pr create --base dev --head stack-a
-gh pr create --base stack-a --head stack-b
+gh pr create --draft --base stack-a --head stack-b
 stack sync              # preview inferred links and repairs
 stack sync --apply      # record links, repair, retarget, refresh stack blocks
 ```
 
 That's the common loop. `stack sync` previews; `stack sync --apply` does the
-work. Repeat after any parent branch changes or a squash merge lands.
+work. The trunk-targeting root is ready; every child remains draft until repair
+makes it a root. Repeat after any parent branch changes or a squash merge lands.
+For an existing GitHub stack opened entirely ready, run
+`gh pr ready --undo <child-pr>` once for each non-root PR; sync does not demote
+already-ready descendants.
 
 ## Commands
 
@@ -67,13 +76,14 @@ work. Repeat after any parent branch changes or a squash merge lands.
 - `stack sync [branch]` — preview inferred links and repairs (non-mutating).
   Scopes to the current stack if no branch is given.
 - `stack sync --apply [branch]` — infer links, remove stale links, repair
-  descendants, retarget changes, refresh stack blocks, show a tree summary.
+  descendants, retarget changes, recreate missing GitHub children as drafts,
+  refresh stack blocks, show a tree summary.
 - `stack sync --apply --keep-going` — process independent stacks separately,
   report successes and failures, exit nonzero if any failed.
 - `stack merge [branch]` — dry-run root merge plus descendant repair. Infers
   the root from the current branch.
 - `stack merge --apply` — retarget child changes, squash-merge the root, repair
-  descendants.
+  descendants, then mark each new GitHub root ready.
 - `stack merge --auto` — retarget children, enable code-host auto-merge, wait,
   then repair descendants.
 - `stack merge --auto --through <branch-or-change>` — repeat auto-merge one root

--- a/src/services/CodeHost.ts
+++ b/src/services/CodeHost.ts
@@ -6,6 +6,12 @@ export type Provider = "github" | "gitlab";
 
 export interface Capabilities {
   readonly adminMerge: boolean;
+  readonly drafts: boolean;
+}
+
+export interface CreateOptions {
+  readonly headRepository?: string | null;
+  readonly draft?: boolean;
 }
 
 export interface Interface {
@@ -25,6 +31,7 @@ export interface Interface {
   readonly change: (number: number) => Effect.Effect<PullMeta, CodeHostError>;
   readonly edit: (pr: number, base: string) => Effect.Effect<void, CodeHostError>;
   readonly body: (pr: number, body: string) => Effect.Effect<void, CodeHostError>;
+  readonly ready: (pr: number) => Effect.Effect<void, CodeHostError>;
   readonly close: (pr: number) => Effect.Effect<void, CodeHostError>;
   readonly create: (
     branch: string,
@@ -32,7 +39,7 @@ export interface Interface {
     title: string,
     body: string,
     labels: ReadonlyArray<string>,
-    headRepository?: string | null,
+    options?: CreateOptions,
   ) => Effect.Effect<PullRef, CodeHostError>;
 }
 

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -266,24 +266,30 @@ export const live = Layer.effect(
       const restoreCurrent = current
         ? runAt(root, "git", ["checkout", current]).pipe(Effect.asVoid, Effect.orDie)
         : Effect.void;
+      const cherryPick = Effect.fn("Git.replay.cherryPick")((commit: string) =>
+        runAt(root, "git", ["cherry-pick", commit]).pipe(
+          Effect.asVoid,
+          Effect.catchTag("ExecError", (err) =>
+            Effect.gen(function* () {
+              if (
+                err.stderr.includes("previous cherry-pick is now empty") ||
+                err.stderr.includes("nothing to commit")
+              ) {
+                yield* runAt(root, "git", ["cherry-pick", "--skip"]);
+                return;
+              }
+              const paths = yield* unmergedPaths().pipe(
+                Effect.catch(() => Effect.succeed([] as ReadonlyArray<string>)),
+              );
+              return yield* new ReplayConflictError(branch, parent, paths, err.stderr);
+            }),
+          ),
+        ),
+      );
 
       yield* Effect.gen(function* () {
         yield* runAt(root, "git", ["checkout", "-B", temp, parent]).pipe(Effect.asVoid);
-        if (commits.length > 0) {
-          yield* runAt(root, "git", ["cherry-pick", "--empty=drop", ...commits]).pipe(
-            Effect.asVoid,
-            Effect.catchTag("ExecError", (err) =>
-              Effect.gen(function* () {
-                const paths = yield* unmergedPaths().pipe(
-                  Effect.catch(() => Effect.succeed([] as ReadonlyArray<string>)),
-                );
-                return yield* Effect.fail(
-                  new ReplayConflictError(branch, parent, paths, err.stderr),
-                );
-              }),
-            ),
-          );
-        }
+        yield* Effect.forEach(commits, cherryPick, { concurrency: 1, discard: true });
         if (owner) {
           yield* runAt(root, "git", ["checkout", branch]).pipe(Effect.asVoid);
           yield* runAt(root, "git", ["reset", "--hard", temp]).pipe(Effect.asVoid);

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1066,7 +1066,10 @@ ${note}`;
                     nextPr.title,
                     nextPr.body,
                     nextPr.labels,
-                    headRepository,
+                    {
+                      headRepository,
+                      draft: codeHost.capabilities.drafts && !trunk(parent),
+                    },
                   );
                   created = made.number;
                   num = made.number;
@@ -1657,7 +1660,13 @@ ${note}`;
                   (worktree) => worktree.branch === target && worktree.path !== cfg.root,
                 ) ?? null)
               : null;
-            const next = scopedState.links.find((item) => item.parent === target)?.branch ?? null;
+            const nextRoots = scopedState.links
+              .filter((item) => item.parent === target)
+              .map((item) => String(item.branch));
+            const next = nextRoots[0] ?? null;
+            const draftRoots = codeHost.capabilities.drafts
+              ? pulls.filter((item) => item.draft && nextRoots.includes(String(item.head)))
+              : [];
             const landed = new Set([reference(Number(pr.number)), String(target)]);
             const preRetargets = (yield* Effect.forEach(
               scopedState.links.filter((item) => item.parent === target),
@@ -1780,6 +1789,10 @@ ${note}`;
                 ? `enable auto-merge ${reference(Number(pr.number))} (${target})`
                 : `${apply ? "" : "would "}${admin ? "admin " : ""}merge ${reference(Number(pr.number))} (${target})`,
               ...(auto ? [`wait for ${reference(Number(pr.number))} to merge`] : []),
+              ...draftRoots.map(
+                (item) =>
+                  `${active ? "" : "would "}mark ${reference(Number(item.number))} (${item.head}) ready`,
+              ),
             ];
 
             const repairAfterMerge = Effect.fn("Stack.land.repairAfterMerge")(() =>
@@ -1811,6 +1824,19 @@ ${note}`;
                   yield* codeHost.changes(),
                 );
                 const notes = yield* linksFor(repair.state, true, landed, repairedPulls);
+                yield* Effect.forEach(
+                  codeHost.capabilities.drafts
+                    ? repairedPulls.filter(
+                        (item) => item.draft && nextRoots.includes(String(item.head)),
+                      )
+                    : [],
+                  (item) =>
+                    Effect.gen(function* () {
+                      yield* step(`mark ${reference(Number(item.number))} (${item.head}) ready`);
+                      yield* codeHost.ready(item.number);
+                    }),
+                  { concurrency: 1, discard: true },
+                );
                 if (current !== target) yield* git.switch(current);
                 const tail = next ? `next root: ${next}` : "next root: none";
                 const view = yield* diagram(branches);

--- a/src/services/code-host/GitHub.ts
+++ b/src/services/code-host/GitHub.ts
@@ -109,7 +109,7 @@ const meta = (row: PullView) =>
 
 const properties = {
   provider: "github" as const,
-  capabilities: { adminMerge: true },
+  capabilities: { adminMerge: true, drafts: true },
   requestLabel: "PR" as const,
   reference: (number: number) => `#${number}`,
   repository: (remote: string, origin?: string) =>
@@ -198,6 +198,10 @@ export const layer = Layer.effect(
       run(["pr", "edit", `${pr}`, "--body", body]).pipe(Effect.asVoid),
     );
 
+    const ready = Effect.fn("CodeHost.github.ready")((pr: number) =>
+      run(["pr", "ready", `${pr}`]).pipe(Effect.asVoid),
+    );
+
     const close = Effect.fn("CodeHost.github.close")((pr: number) =>
       run(["pr", "close", `${pr}`]).pipe(Effect.asVoid),
     );
@@ -208,8 +212,9 @@ export const layer = Layer.effect(
       title: string,
       body: string,
       labels: ReadonlyArray<string>,
-      headRepository?: string | null,
+      options?: CodeHost.CreateOptions,
     ) {
+      const headRepository = options?.headRepository;
       const head = headRepository ? `${headRepository.split("/")[0]}:${branch}` : branch;
       const created = yield* run([
         "pr",
@@ -223,6 +228,7 @@ export const layer = Layer.effect(
         "--body",
         body,
         ...labels.flatMap((label) => ["--label", label]),
+        ...(options?.draft ? ["--draft"] : []),
       ]);
 
       const number = Number(created.trim().match(/\/pull\/(\d+)\/?$/)?.[1]);
@@ -236,7 +242,7 @@ export const layer = Layer.effect(
         headRepository: headRepository?.toLowerCase() ?? null,
         base,
         url: created.trim(),
-        draft: false,
+        draft: options?.draft ?? false,
       });
     });
 
@@ -249,6 +255,7 @@ export const layer = Layer.effect(
       change,
       edit,
       body,
+      ready,
       close,
       create,
     });

--- a/src/services/code-host/GitLab.ts
+++ b/src/services/code-host/GitLab.ts
@@ -112,7 +112,7 @@ const meta = (row: MRView, headRepository: string | null) =>
 
 const properties = {
   provider: "gitlab" as const,
-  capabilities: { adminMerge: false },
+  capabilities: { adminMerge: false, drafts: false },
   requestLabel: "MR" as const,
   reference: (number: number) => `!${number}`,
   repository: CodeHost.repositoryFor,
@@ -236,6 +236,10 @@ export const layer = Layer.effect(
       ]).pipe(Effect.asVoid),
     );
 
+    const ready = Effect.fn("CodeHost.gitlab.ready")((_pr: number) =>
+      Effect.fail(new UnsupportedCodeHostOperation("gitlab", "draft changes")),
+    );
+
     const close = Effect.fn("CodeHost.gitlab.close")((pr: number) =>
       run(["mr", "close", `${pr}`]).pipe(Effect.asVoid),
     );
@@ -246,8 +250,12 @@ export const layer = Layer.effect(
       title: string,
       body: string,
       labels: ReadonlyArray<string>,
-      headRepository?: string | null,
+      options?: CodeHost.CreateOptions,
     ) {
+      if (options?.draft) {
+        return yield* new UnsupportedCodeHostOperation("gitlab", "draft changes");
+      }
+      const headRepository = options?.headRepository;
       const created = yield* run([
         "mr",
         "create",
@@ -288,6 +296,7 @@ export const layer = Layer.effect(
       change,
       edit,
       body,
+      ready,
       close,
       create,
     });

--- a/src/services/code-host/Memory.ts
+++ b/src/services/code-host/Memory.ts
@@ -144,17 +144,20 @@ export const layer = (opts: Options) =>
         title: string,
         body: string,
         labels: ReadonlyArray<string>,
-        headRepository?: string | null,
+        options?: CodeHost.CreateOptions,
       ) {
+        if (options?.draft && !opts.properties.capabilities.drafts) {
+          return yield* new UnsupportedCodeHostOperation(opts.properties.provider, "draft changes");
+        }
         const number = next++;
         const made = pullRef({
           number,
           title,
           head: branch,
-          headRepository: headRepository ?? null,
+          headRepository: options?.headRepository ?? null,
           base,
           url: opts.url(number),
-          draft: false,
+          draft: options?.draft ?? false,
         });
         yield* record(`create ${branch} ${base}`);
         yield* Ref.update(pullsRef, (pulls) => [...pulls, made]);
@@ -166,7 +169,7 @@ export const layer = (opts: Options) =>
               title,
               body,
               head: branch,
-              headRepository: headRepository ?? null,
+              headRepository: options?.headRepository ?? null,
               base,
               url: made.url,
               draft: made.draft,
@@ -176,6 +179,51 @@ export const layer = (opts: Options) =>
           ),
         );
         return made;
+      });
+      const ready = Effect.fn("CodeHost.memory.ready")(function* (pr: number) {
+        if (!opts.properties.capabilities.drafts) {
+          return yield* new UnsupportedCodeHostOperation(opts.properties.provider, "draft changes");
+        }
+        yield* requireOpen(pr);
+        yield* record(`ready ${pr}`);
+        yield* Ref.update(pullsRef, (pulls) =>
+          pulls.map((item) =>
+            item.number === pr
+              ? pullRef({
+                  number: item.number,
+                  title: item.title,
+                  head: item.head,
+                  headRepository: item.headRepository,
+                  base: item.base,
+                  url: item.url,
+                  draft: false,
+                  checks: item.checks,
+                })
+              : item,
+          ),
+        );
+        yield* Ref.update(metasRef, (metas) => {
+          const nextMetas = new Map(metas);
+          const current = nextMetas.get(pr);
+          if (current) {
+            nextMetas.set(
+              pr,
+              pullMeta({
+                number: current.number,
+                title: current.title,
+                body: current.body,
+                head: current.head,
+                headRepository: current.headRepository,
+                base: current.base,
+                url: current.url,
+                draft: false,
+                state: current.state,
+                labels: current.labels,
+              }),
+            );
+          }
+          return nextMetas;
+        });
       });
       const close = Effect.fn("CodeHost.memory.close")((pr: number) =>
         Effect.gen(function* () {
@@ -213,6 +261,7 @@ export const layer = (opts: Options) =>
         change,
         edit,
         body,
+        ready,
         close,
         create,
       });

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1325,8 +1325,49 @@ describe("Git", () => {
         ["git", "worktree", "list", "--porcelain", "-z"],
         ["git", "branch", "--show-current"],
         ["git", "checkout", "-B", temp, "dev"],
-        ["git", "cherry-pick", "--empty=drop", "b1"],
+        ["git", "cherry-pick", "b1"],
         ["git", "diff", "--name-only", "--diff-filter=U"],
+        ["git", "cherry-pick", "--abort"],
+        ["git", "checkout", "stack-c"],
+        ["git", "branch", "-D", temp],
+      ]);
+    }).pipe(Effect.provide(Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))));
+  });
+
+  it.effect("replay skips commits that become empty on older Git versions", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.gen(function* () {
+            calls.push([tool, ...args]);
+            if (args[0] === "branch" && args[1] === "--show-current") return "stack-c";
+            if (args[0] === "cherry-pick" && args[1] === "b1") {
+              return yield* Effect.fail(
+                new ExecError(tool, args, 1, "The previous cherry-pick is now empty"),
+              );
+            }
+            return "";
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      yield* TestClock.setTime(1_700_000_000_000);
+      const git = yield* Git.Service;
+
+      yield* git.replay("stack-b", "dev", ["b1", "b2"]);
+
+      const temp = calls[2]?.[3];
+      expect(calls).toEqual([
+        ["git", "worktree", "list", "--porcelain", "-z"],
+        ["git", "branch", "--show-current"],
+        ["git", "checkout", "-B", temp, "dev"],
+        ["git", "cherry-pick", "b1"],
+        ["git", "cherry-pick", "--skip"],
+        ["git", "cherry-pick", "b2"],
+        ["git", "branch", "-f", "stack-b", temp],
         ["git", "cherry-pick", "--abort"],
         ["git", "checkout", "stack-c"],
         ["git", "branch", "-D", temp],

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -98,7 +98,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     restore: () => Effect.void,
     push: () => Effect.void,
     provider: "github",
-    capabilities: { adminMerge: true },
+    capabilities: { adminMerge: true, drafts: true },
     requestLabel: "PR",
     reference: (number) => `#${number}`,
     repository: CodeHost.repositoryFor,
@@ -110,6 +110,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     change: (number) => Effect.fail(new CodeHostChangeNotFoundError(number)),
     edit: () => Effect.void,
     body: () => Effect.void,
+    ready: () => Effect.void,
     close: () => Effect.void,
     create: (branch, base) => Effect.fail(unused("gh", ["pr", "create", branch, base])),
   };
@@ -307,7 +308,7 @@ const integrationGitHub = (opts: {
 
       return CodeHost.Service.of({
         provider: "github",
-        capabilities: { adminMerge: true },
+        capabilities: { adminMerge: true, drafts: true },
         requestLabel: "PR",
         reference: (number) => `#${number}`,
         repository: CodeHost.repositoryFor,
@@ -319,6 +320,7 @@ const integrationGitHub = (opts: {
         change: getPull,
         edit,
         body: updateBody,
+        ready: () => Effect.void,
         close: (pr) => Ref.update(pulls, (items) => items.filter((item) => item.number !== pr)),
         create,
       });
@@ -836,6 +838,7 @@ const makeLand = (
   codeHost: Partial<Git.Interface & CodeHost.Interface> = {},
   includeUnrelatedRoot = false,
   forkStackC = false,
+  childDraft = false,
 ) => {
   const seen: Array<string> = [];
   const refs = new Map([
@@ -860,7 +863,7 @@ const makeLand = (
       head: "stack-b",
       base: "stack-a",
       url: "u5",
-      draft: false,
+      draft: childDraft,
     }),
     pullRef({
       number: 3,
@@ -1019,6 +1022,21 @@ const makeLand = (
             }),
           body: (pr: number, body: string) =>
             Effect.sync(() => void seen.push(`body ${pr} ${body.includes("### [Stack]")}`)),
+          ready: (pr: number) =>
+            Effect.sync(() => {
+              seen.push(`ready ${pr}`);
+              pulls = pulls.map((pull) =>
+                pull.number === pr
+                  ? pullRef({
+                      number: pull.number,
+                      head: pull.head,
+                      base: pull.base,
+                      url: pull.url,
+                      draft: false,
+                    })
+                  : pull,
+              );
+            }),
           close: () => Effect.void,
           create: (
             branch: string,
@@ -1785,18 +1803,56 @@ describe("GitHub", () => {
 
     return Effect.gen(function* () {
       const github = yield* CodeHost.Service;
-      const created = yield* github.create(
-        "feature/x",
-        "main",
-        "restacked",
-        "body",
-        [],
-        "contributor/project",
-      );
+      const created = yield* github.create("feature/x", "main", "restacked", "body", [], {
+        headRepository: "contributor/project",
+      });
 
       expect(Number(created.number)).toBe(7);
       expect(String(created.url)).toBe("https://github.com/upstream/project/pull/7");
       expect(calls).toHaveLength(1);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("creates draft GitHub pull requests and marks them ready", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            return args[1] === "create" ? "https://github.com/owner/project/pull/7" : "";
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const created = yield* github.create("feature/x", "main", "draft", "body", [], {
+        draft: true,
+      });
+      yield* github.ready(created.number);
+
+      expect(created.draft).toBe(true);
+      expect(calls).toEqual([
+        [
+          "gh",
+          "pr",
+          "create",
+          "--head",
+          "feature/x",
+          "--base",
+          "main",
+          "--title",
+          "draft",
+          "--body",
+          "body",
+          "--draft",
+        ],
+        ["gh", "pr", "ready", "7"],
+      ]);
     }).pipe(
       Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
     );
@@ -2179,14 +2235,9 @@ describe("GitLab", () => {
 
     return Effect.gen(function* () {
       const gitlab = yield* CodeHost.Service;
-      const created = yield* gitlab.create(
-        "feature/x",
-        "main",
-        "restacked",
-        "body",
-        [],
-        "contributor/project",
-      );
+      const created = yield* gitlab.create("feature/x", "main", "restacked", "body", [], {
+        headRepository: "contributor/project",
+      });
 
       expect(Number(created.number)).toBe(7);
       expect(String(created.url)).toBe("https://gitlab.com/upstream/project/-/merge_requests/7");
@@ -2547,6 +2598,7 @@ describe("Stack", () => {
 
   it.effect("sync refreshes stack blocks for requests created during repair", () => {
     const seen: Array<string> = [];
+    const drafts = new Array<boolean | undefined>();
     let pulls = [pr(2, "active-child", "active-root")];
     const layer = stackTestLayer({
       current: "active-child",
@@ -2572,9 +2624,16 @@ describe("Stack", () => {
             ? Effect.succeed(metaFor(found))
             : Effect.fail(new CodeHostChangeNotFoundError(number));
         },
-        create: (branch, base) =>
+        create: (branch, base, _title, _body, _labels, options) =>
           Effect.sync(() => {
-            const made = pr(3, branch, base);
+            drafts.push(options?.draft);
+            const made = pullRef({
+              number: 3,
+              head: branch,
+              base,
+              url: "u3",
+              draft: options?.draft ?? false,
+            });
             pulls = [...pulls, made];
             return made;
           }),
@@ -2587,6 +2646,53 @@ describe("Stack", () => {
       yield* stack.sync({ branch: "active-child", apply: true });
 
       expect(seen).toContain("body 3");
+      expect(drafts).toEqual([false]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("sync recreates missing descendant pull requests as drafts", () => {
+    const drafts = new Array<boolean | undefined>();
+    let pulls = [pr(1, "root", "dev"), pr(3, "leaf", "child")];
+    const layer = stackTestLayer({
+      current: "leaf",
+      refs: [ref("dev"), ref("root"), ref("child"), ref("leaf")],
+      pulls,
+      bases: bases(["root", "dev", "dev"], ["child", "root", "root"], ["leaf", "child", "child"]),
+      state: stackState([
+        stackLink({ branch: "root", parent: "dev", anchor: "dev", pr: 1 }),
+        stackLink({ branch: "child", parent: "root", anchor: "root", pr: 2 }),
+        stackLink({ branch: "leaf", parent: "child", anchor: "child", pr: 3 }),
+      ]),
+      service: {
+        changes: () => Effect.succeed(pulls),
+        change: (number) => {
+          const found = pulls.find((item) => item.number === number);
+          return found
+            ? Effect.succeed(metaFor(found))
+            : Effect.fail(new CodeHostChangeNotFoundError(number));
+        },
+        create: (branch, base, _title, _body, _labels, options) =>
+          Effect.sync(() => {
+            drafts.push(options?.draft);
+            const made = pullRef({
+              number: 4,
+              head: branch,
+              base,
+              url: "u4",
+              draft: options?.draft ?? false,
+            });
+            pulls = [...pulls, made];
+            return made;
+          }),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.sync({ branch: "leaf", apply: true });
+
+      expect(drafts).toEqual([true]);
+      expect(pulls.find((item) => item.head === "child")?.draft).toBe(true);
     }).pipe(Effect.provide(layer));
   });
 
@@ -3295,7 +3401,7 @@ describe("Stack", () => {
   it.effect("links use scannable GitLab MR references with titles", () => {
     const test = makeSync({
       provider: "gitlab",
-      capabilities: { adminMerge: false },
+      capabilities: { adminMerge: false, drafts: false },
       requestLabel: "MR",
       reference: (number) => `!${number}`,
     });
@@ -3550,6 +3656,19 @@ describe("Stack", () => {
           }).pipe(Effect.provide(doneTest.layer)),
         ),
       );
+  });
+
+  it.effect("land marks a draft child ready after repairing it into the next root", () => {
+    const test = makeLand([], "stack-a", null, {}, false, false, true);
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const output = yield* stack.land("stack-a", { apply: true });
+
+      expect(output).toContain("mark #5 (stack-b) ready");
+      expect(test.seen).toContain("ready 5");
+      expect(test.seen.indexOf("ready 5")).toBeGreaterThan(test.seen.indexOf("push stack-b"));
+    }).pipe(Effect.provide(test.layer));
   });
 
   it.effect("land journals child retargets before a failed root merge", () => {
@@ -3813,13 +3932,15 @@ describe("Stack", () => {
         },
         push: (branch, remote = "origin") =>
           Effect.sync(() => void seen.push(`push ${branch} ${remote}`)),
-        create: (branch, base, _title, _body, _labels, headRepository) =>
+        create: (branch, base, _title, _body, _labels, options) =>
           Effect.sync(() => {
-            seen.push(`create ${headRepository}`);
+            seen.push(`create ${options?.headRepository}`);
             const made = pullRef({
               number: 5,
               head: branch,
-              ...(headRepository === undefined ? {} : { headRepository }),
+              ...(options?.headRepository === undefined
+                ? {}
+                : { headRepository: options.headRepository }),
               base,
               url: "u5",
               draft: false,
@@ -4020,7 +4141,7 @@ describe("Stack", () => {
   it.effect("land rejects GitLab admin merge before mutation", () => {
     const test = makeLand([], "stack-a", null, {
       provider: "gitlab",
-      capabilities: { adminMerge: false },
+      capabilities: { adminMerge: false, drafts: false },
       requestLabel: "MR",
       reference: (number) => `!${number}`,
     });


### PR DESCRIPTION
GitHub stacks can now keep only the trunk-targeting merge candidate ready while higher descendants remain draft.

## Why

Every descendant currently starts CI and automated review even though parent merges will restack it repeatedly. That creates avoidable work and noisy reviews against intermediate commits.

## Key changes

- Add capability-gated draft creation and ready promotion to the code-host contract.
- Recreate missing GitHub child PRs as drafts; trunk-targeting replacements remain ready.
- After a root merge repairs and pushes descendants, mark each direct child that became a new root ready.
- Leave GitLab draft state unmanaged.
- Replay cherry-picks individually so the CLI still works on Git versions without `cherry-pick --empty=drop`.

Existing already-ready descendants are intentionally not demoted automatically; the skill documents the one-time `gh pr ready --undo` migration.

## Risk and verification

The main ordering risk is triggering review before a repaired branch is final. Promotion occurs only after repair, push, PR retargeting, and stack-block refresh succeed.

Verified:

```bash
bun run test          # 138 passed
bun run typecheck
bun run lint
bun run format:check
bun run package:smoke
./dist/cli.js --help
```

## Rollback

Revert the two commits; the code-host capability keeps GitLab behavior isolated.
