### PR TITLE
fix(git): support repair on older Git versions

### DIFF
--- a/.changeset/clean-apples-replay.md
+++ b/.changeset/clean-apples-replay.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/stack": patch
+---
+
+Support stack repair on Git installations that do not provide `cherry-pick --empty=drop`.

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -266,24 +266,30 @@ export const live = Layer.effect(
       const restoreCurrent = current
         ? runAt(root, "git", ["checkout", current]).pipe(Effect.asVoid, Effect.orDie)
         : Effect.void;
+      const cherryPick = Effect.fn("Git.replay.cherryPick")((commit: string) =>
+        runAt(root, "git", ["cherry-pick", commit]).pipe(
+          Effect.asVoid,
+          Effect.catchTag("ExecError", (err) =>
+            Effect.gen(function* () {
+              if (
+                err.stderr.includes("previous cherry-pick is now empty") ||
+                err.stderr.includes("nothing to commit")
+              ) {
+                yield* runAt(root, "git", ["cherry-pick", "--skip"]);
+                return;
+              }
+              const paths = yield* unmergedPaths().pipe(
+                Effect.catch(() => Effect.succeed([] as ReadonlyArray<string>)),
+              );
+              return yield* new ReplayConflictError(branch, parent, paths, err.stderr);
+            }),
+          ),
+        ),
+      );
 
       yield* Effect.gen(function* () {
         yield* runAt(root, "git", ["checkout", "-B", temp, parent]).pipe(Effect.asVoid);
-        if (commits.length > 0) {
-          yield* runAt(root, "git", ["cherry-pick", "--empty=drop", ...commits]).pipe(
-            Effect.asVoid,
-            Effect.catchTag("ExecError", (err) =>
-              Effect.gen(function* () {
-                const paths = yield* unmergedPaths().pipe(
-                  Effect.catch(() => Effect.succeed([] as ReadonlyArray<string>)),
-                );
-                return yield* Effect.fail(
-                  new ReplayConflictError(branch, parent, paths, err.stderr),
-                );
-              }),
-            ),
-          );
-        }
+        yield* Effect.forEach(commits, cherryPick, { concurrency: 1, discard: true });
         if (owner) {
           yield* runAt(root, "git", ["checkout", branch]).pipe(Effect.asVoid);
           yield* runAt(root, "git", ["reset", "--hard", temp]).pipe(Effect.asVoid);

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1325,8 +1325,49 @@ describe("Git", () => {
         ["git", "worktree", "list", "--porcelain", "-z"],
         ["git", "branch", "--show-current"],
         ["git", "checkout", "-B", temp, "dev"],
-        ["git", "cherry-pick", "--empty=drop", "b1"],
+        ["git", "cherry-pick", "b1"],
         ["git", "diff", "--name-only", "--diff-filter=U"],
+        ["git", "cherry-pick", "--abort"],
+        ["git", "checkout", "stack-c"],
+        ["git", "branch", "-D", temp],
+      ]);
+    }).pipe(Effect.provide(Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))));
+  });
+
+  it.effect("replay skips commits that become empty on older Git versions", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.gen(function* () {
+            calls.push([tool, ...args]);
+            if (args[0] === "branch" && args[1] === "--show-current") return "stack-c";
+            if (args[0] === "cherry-pick" && args[1] === "b1") {
+              return yield* Effect.fail(
+                new ExecError(tool, args, 1, "The previous cherry-pick is now empty"),
+              );
+            }
+            return "";
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      yield* TestClock.setTime(1_700_000_000_000);
+      const git = yield* Git.Service;
+
+      yield* git.replay("stack-b", "dev", ["b1", "b2"]);
+
+      const temp = calls[2]?.[3];
+      expect(calls).toEqual([
+        ["git", "worktree", "list", "--porcelain", "-z"],
+        ["git", "branch", "--show-current"],
+        ["git", "checkout", "-B", temp, "dev"],
+        ["git", "cherry-pick", "b1"],
+        ["git", "cherry-pick", "--skip"],
+        ["git", "cherry-pick", "b2"],
+        ["git", "branch", "-f", "stack-b", temp],
         ["git", "cherry-pick", "--abort"],
         ["git", "checkout", "stack-c"],
         ["git", "branch", "-D", temp],


### PR DESCRIPTION
Makes stack repair work on Git installations that do not support `cherry-pick --empty=drop`, including Apple Git 2.39.5.

## Why

The current replay command exits at argument parsing on these installations, so otherwise valid stack repairs fail before any commit is replayed.

## Fix

- Replay commits sequentially without the unsupported option.
- Skip commits only when Git reports that the active cherry-pick became empty.
- Preserve the existing conflict path for every other failure.
- Add focused coverage for empty-commit handling and a patch changeset.

## Risk and review focus

**Risk:** Git reports empty cherry-picks through stderr rather than a dedicated status.
→ Detection is limited to the two known empty-pick messages; other errors still surface as `ReplayConflictError` with unmerged paths.

## Test plan

```bash
bun run typecheck
bun run test
bun run lint
bun run format:check
bun run package:smoke
bun run changeset:status --since upstream/main
```

Verified on Apple Git 2.39.5: all 135 tests pass.

## Rollback

Revert this PR to restore the existing multi-commit `cherry-pick --empty=drop` replay path.
