### PR TITLE
fix(github): merge native stacks asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ stack merge --apply
 Use `stack merge --auto` when the code host should wait for merge requirements,
 then repair descendants automatically after the root lands.
 
+GitHub-native stacked PRs use GitHub's asynchronous stack merge API. Kit fails
+closed when that API would merge another open PR below the selected root;
+GitHub does not support admin bypass or persistent auto-merge for native stacks.
+
 ## What It Does
 
 `stack sync --apply` is the common maintenance workflow:

--- a/dev/build-cli.ts
+++ b/dev/build-cli.ts
@@ -1,5 +1,11 @@
 import { chmod } from "node:fs/promises";
 
+const buildRuntime = "1.3.1";
+if (Bun.version !== buildRuntime) {
+  console.error(`stack bundles require Bun ${buildRuntime}; found ${Bun.version}`);
+  process.exit(1);
+}
+
 const result = await Bun.build({
   entrypoints: ["src/cli.ts"],
   format: "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.8",
+  "version": "0.4.2-anchor-fix.9",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.13",
+  "version": "0.4.2-anchor-fix.14",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.4",
+  "version": "0.4.2-anchor-fix.5",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.5",
+  "version": "0.4.2-anchor-fix.6",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2",
+  "version": "0.4.2-anchor-fix.4",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.6",
+  "version": "0.4.2-anchor-fix.7",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.9",
+  "version": "0.4.2-anchor-fix.10",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.10",
+  "version": "0.4.2-anchor-fix.11",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",
@@ -63,5 +63,6 @@
     "oxlint": "^1.66.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
-  }
+  },
+  "packageManager": "bun@1.3.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.7",
+  "version": "0.4.2-anchor-fix.8",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.11",
+  "version": "0.4.2-anchor-fix.12",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitlangton/stack",
-  "version": "0.4.2-anchor-fix.12",
+  "version": "0.4.2-anchor-fix.13",
   "description": "Squash-safe stacked PR/MR repair CLI for GitHub and GitLab",
   "keywords": [
     "cli",

--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -74,6 +74,9 @@ work. Repeat after any parent branch changes or a squash merge lands.
   the root from the current branch.
 - `stack merge [branch] --repair-depth 2` — limit the preview and repair to the
   root plus two descendant layers. Deeper tracked links remain untouched.
+- `stack merge [branch] --repair-depth 0` — merge only the root when a
+  descendant cannot yet be repaired. Descendant links remain untouched for a
+  later sync.
 - `stack merge --apply` — retarget child changes, squash-merge the root, repair
   descendants.
 - `stack merge --auto` — retarget children, enable code-host auto-merge, wait,

--- a/skills/stack/SKILL.md
+++ b/skills/stack/SKILL.md
@@ -72,6 +72,8 @@ work. Repeat after any parent branch changes or a squash merge lands.
   report successes and failures, exit nonzero if any failed.
 - `stack merge [branch]` — dry-run root merge plus descendant repair. Infers
   the root from the current branch.
+- `stack merge [branch] --repair-depth 2` — limit the preview and repair to the
+  root plus two descendant layers. Deeper tracked links remain untouched.
 - `stack merge --apply` — retarget child changes, squash-merge the root, repair
   descendants.
 - `stack merge --auto` — retarget children, enable code-host auto-merge, wait,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,13 @@ const through = Flag.string("through").pipe(
   Flag.optional,
 );
 
+const repairDepth = Flag.integer("repair-depth").pipe(
+  Flag.withDescription(
+    "Limit root-merge repair to this many descendant layers. The immediate child is depth 1.",
+  ),
+  Flag.optional,
+);
+
 const continueOnFailure = Flag.boolean("continue-on-failure").pipe(
   Flag.withAlias("keep-going"),
   Flag.withDescription(
@@ -176,21 +183,24 @@ const mergeCommand = Command.make(
     auto,
     admin,
     through,
+    repairDepth,
   },
-  Effect.fn(function* ({ branch, apply, auto, admin, through }) {
+  Effect.fn(function* ({ branch, apply, auto, admin, through, repairDepth }) {
     const stack = yield* Stack;
     const throughValue = Option.getOrUndefined(through);
+    const repairDepthValue = Option.getOrUndefined(repairDepth);
     const items = yield* stack.land(Option.getOrUndefined(branch), {
       apply,
       auto,
       admin,
       ...(throughValue === undefined ? {} : { through: throughValue }),
+      ...(repairDepthValue === undefined ? {} : { repairDepth: repairDepthValue }),
     });
     yield* Console.log(items.join("\n"));
   }),
 ).pipe(
   Command.withDescription(
-    "Merge the oldest branch in a stack, preserve a local backup branch, repair descendants, and print the next root branch. If branch is omitted, infer the root from the current branch. By default this is a dry run. Add --apply to merge immediately, --apply --admin to force with admin privileges (GitHub only), or --auto to enable code-host auto-merge and wait until it lands before repairing descendants. Add --auto --through <branch-or-change> for a bounded range.",
+    "Merge the oldest branch in a stack, preserve a local backup branch, repair descendants, and print the next root branch. If branch is omitted, infer the root from the current branch. By default this is a dry run. Add --repair-depth <n> to bound repair to n descendant layers. Add --apply to merge immediately, --apply --admin to force with admin privileges (GitHub only), or --auto to enable code-host auto-merge and wait until it lands before repairing descendants. Add --auto --through <branch-or-change> for a bounded range.",
   ),
   Command.withExamples([
     {
@@ -204,6 +214,10 @@ const mergeCommand = Command.make(
     {
       command: "stack merge effectify-watcher --apply",
       description: "Merge the root change, repair descendants, and print the next root branch",
+    },
+    {
+      command: "stack merge effectify-watcher --repair-depth 2",
+      description: "Preview the root plus at most two descendant repair layers",
     },
     {
       command: "stack merge effectify-watcher --auto",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ const through = Flag.string("through").pipe(
 
 const repairDepth = Flag.integer("repair-depth").pipe(
   Flag.withDescription(
-    "Limit root-merge repair to this many descendant layers. The immediate child is depth 1.",
+    "Limit root-merge repair to this many descendant layers. Use 0 for the root only; the immediate child is depth 1.",
   ),
   Flag.optional,
 );
@@ -208,7 +208,7 @@ const mergeCommand = Command.make(
   }),
 ).pipe(
   Command.withDescription(
-    "Merge the oldest branch in a stack, preserve a local backup branch, repair descendants, and print the next root branch. If branch is omitted, infer the root from the current branch. By default this is a dry run. Add --repair-depth <n> to bound repair to n descendant layers. Add --apply to merge immediately, --apply --admin to force with admin privileges (GitHub only), or --auto to enable code-host auto-merge and wait until it lands before repairing descendants. Add --auto --through <branch-or-change> for a bounded range.",
+    "Merge the oldest branch in a stack, preserve a local backup branch, repair descendants, and print the next root branch. If branch is omitted, infer the root from the current branch. By default this is a dry run. Add --repair-depth <n> to bound repair to n descendant layers; use 0 to merge only the root. Add --apply to merge immediately, --apply --admin to force with admin privileges (GitHub only), or --auto to enable code-host auto-merge and wait until it lands before repairing descendants. Add --auto --through <branch-or-change> for a bounded range.",
   ),
   Command.withExamples([
     {
@@ -226,6 +226,10 @@ const mergeCommand = Command.make(
     {
       command: "stack merge effectify-watcher --repair-depth 2",
       description: "Preview the root plus at most two descendant repair layers",
+    },
+    {
+      command: "stack merge effectify-watcher --repair-depth 0",
+      description: "Preview a root-only merge without descendant repair",
     },
     {
       command: "stack merge effectify-watcher --auto",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,10 +102,14 @@ const trackCommand = Command.make(
       Flag.withAlias("p"),
       Flag.withDescription("Parent branch this branch is stacked on"),
     ),
+    anchor: Flag.string("anchor").pipe(
+      Flag.optional,
+      Flag.withDescription("Existing commit after which this branch's own commits begin"),
+    ),
   },
-  Effect.fn(function* ({ branch, onto }) {
+  Effect.fn(function* ({ branch, onto, anchor }) {
     const stack = yield* Stack;
-    const link = yield* stack.adopt(branch, onto);
+    const link = yield* stack.adopt(branch, onto, Option.getOrUndefined(anchor));
     yield* Console.log(`track ${link.branch} onto ${link.parent} @ ${link.anchor}`);
   }),
 ).pipe(
@@ -116,6 +120,10 @@ const trackCommand = Command.make(
     {
       command: "stack track stack-c --onto stack-b",
       description: "Record that stack-c is stacked on stack-b",
+    },
+    {
+      command: "stack track stack-c --onto stack-b --anchor abc123",
+      description: "Preserve the old parent boundary after repairing stack-b manually",
     },
   ]),
 );

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -274,6 +274,26 @@ export class CodeHostChangeNotFoundError extends Schema.TaggedErrorClass<CodeHos
   }
 }
 
+export class CodeHostReplayBaseNotFoundError extends Schema.TaggedErrorClass<CodeHostReplayBaseNotFoundError>()(
+  "CodeHostReplayBaseNotFoundError",
+  {
+    number: Schema.Number,
+    branch: Schema.String,
+    message: Schema.String,
+  },
+) {
+  constructor(
+    readonly number: number,
+    readonly branch: string,
+  ) {
+    super({
+      number,
+      branch,
+      message: `cannot recover the merged change for previous base ${branch} of change ${number}`,
+    });
+  }
+}
+
 export class UnsupportedCodeHostOperation extends Schema.TaggedErrorClass<UnsupportedCodeHostOperation>()(
   "UnsupportedCodeHostOperation",
   {
@@ -295,11 +315,13 @@ export type CodeHostError =
   | ExecError
   | CodeHostDecodeError
   | CodeHostChangeNotFoundError
+  | CodeHostReplayBaseNotFoundError
   | UnsupportedCodeHostOperation;
 export type StackError =
   | ExecError
   | CodeHostDecodeError
   | CodeHostChangeNotFoundError
+  | CodeHostReplayBaseNotFoundError
   | UnsupportedCodeHostOperation
   | StateError
   | BranchError

--- a/src/repairExecution.ts
+++ b/src/repairExecution.ts
@@ -1,5 +1,11 @@
 import * as Effect from "effect/Effect";
-import type { ExecError, ReplayConflictError, StackError } from "./domain/model.ts";
+import * as Option from "effect/Option";
+import {
+  type ExecError,
+  type ReplayConflictError,
+  type StackError,
+  StackOperationError,
+} from "./domain/model.ts";
 import type { RebaseBranchPlan, RetargetPullPlan } from "./repairPlan.ts";
 import type { Interface as Git } from "./services/Git.ts";
 import * as StackResult from "./stackResult.ts";
@@ -10,7 +16,8 @@ interface Dependencies {
 }
 
 export interface ApplyRebaseBranchDependencies extends Dependencies {
-  readonly git: Pick<Git, "backup" | "replay" | "push">;
+  readonly git: Pick<Git, "backup" | "replay" | "push" | "head" | "remoteHead">;
+  readonly complete: (item: StackResult.StackResultItem) => Effect.Effect<void, StackError>;
   readonly onReplayFailure: (error: ExecError | ReplayConflictError) => StackError;
 }
 
@@ -18,18 +25,72 @@ export const applyRebaseBranch = Effect.fn("RepairExecution.applyRebaseBranch")(
   plan: RebaseBranchPlan,
   deps: ApplyRebaseBranchDependencies,
 ) {
+  const [originalHead, ontoHead] = yield* Effect.all([
+    deps.git.head(plan.branch),
+    deps.git.head(plan.onto),
+  ]);
+  if (Option.isNone(originalHead)) {
+    return yield* Effect.fail(
+      new StackOperationError(`cannot resolve local head for ${plan.branch}`),
+    );
+  }
+  if (Option.isNone(ontoHead)) {
+    return yield* Effect.fail(
+      new StackOperationError(`cannot resolve target head for ${plan.onto}`),
+    );
+  }
+
   yield* deps.checkpoint();
   yield* deps.step(`backup ${plan.branch} -> ${plan.backup}`);
   yield* deps.git.backup(plan.branch, plan.backup);
+  yield* deps.complete({
+    _tag: "Backup",
+    mode: "apply",
+    branch: plan.branch,
+    backup: plan.backup,
+  });
   yield* deps.step(`rebase ${plan.branch} onto ${plan.parent}`);
   yield* deps.git
     .replay(plan.branch, plan.onto, plan.commits)
     .pipe(Effect.mapError(deps.onReplayFailure));
+  const replayedHead = yield* deps.git.head(plan.branch);
+  if (Option.isNone(replayedHead) || replayedHead.value === originalHead.value) {
+    return yield* Effect.fail(
+      new StackOperationError(
+        `rebase ${plan.branch} did not update local head ${originalHead.value}`,
+      ),
+    );
+  }
+  yield* deps.complete({
+    _tag: "Rebase",
+    mode: "apply",
+    branch: plan.branch,
+    parent: plan.parent,
+  });
   for (const remote of plan.pushRemotes) {
     yield* deps.step(
       StackResult.render({ _tag: "Push", mode: "apply", branch: plan.branch, remotes: [remote] }),
     );
     yield* deps.git.push(plan.branch, remote);
+    const remoteHead = yield* deps.git.remoteHead(remote, plan.branch);
+    if (Option.isNone(remoteHead)) {
+      return yield* Effect.fail(
+        new StackOperationError(`cannot verify ${plan.branch} on remote ${remote}`),
+      );
+    }
+    if (remoteHead.value !== replayedHead.value) {
+      return yield* Effect.fail(
+        new StackOperationError(
+          `${remote} head ${remoteHead.value} does not match local head ${replayedHead.value} for ${plan.branch}`,
+        ),
+      );
+    }
+    yield* deps.complete({
+      _tag: "Push",
+      mode: "apply",
+      branch: plan.branch,
+      remotes: [remote],
+    });
   }
 });
 

--- a/src/repairExecution.ts
+++ b/src/repairExecution.ts
@@ -39,6 +39,9 @@ export const applyRebaseBranch = Effect.fn("RepairExecution.applyRebaseBranch")(
       new StackOperationError(`cannot resolve target head for ${plan.onto}`),
     );
   }
+  const expectedRemoteHeads = yield* Effect.all(
+    plan.pushRemotes.map((remote) => deps.git.remoteHead(remote, plan.branch)),
+  );
 
   yield* deps.checkpoint();
   yield* deps.step(`backup ${plan.branch} -> ${plan.backup}`);
@@ -67,11 +70,15 @@ export const applyRebaseBranch = Effect.fn("RepairExecution.applyRebaseBranch")(
     branch: plan.branch,
     parent: plan.parent,
   });
-  for (const remote of plan.pushRemotes) {
+  for (const [index, remote] of plan.pushRemotes.entries()) {
     yield* deps.step(
       StackResult.render({ _tag: "Push", mode: "apply", branch: plan.branch, remotes: [remote] }),
     );
-    yield* deps.git.push(plan.branch, remote);
+    yield* deps.git.push(
+      plan.branch,
+      remote,
+      Option.getOrNull(expectedRemoteHeads[index] ?? Option.none()),
+    );
     const remoteHead = yield* deps.git.remoteHead(remote, plan.branch);
     if (Option.isNone(remoteHead)) {
       return yield* Effect.fail(

--- a/src/services/CodeHost.ts
+++ b/src/services/CodeHost.ts
@@ -22,6 +22,7 @@ export interface ReplayMergedParent {
   readonly branch: string;
   readonly currentBase: string;
   readonly head: string;
+  readonly historicalHeads: ReadonlyArray<string>;
   readonly fetchRef: string;
   readonly change: number;
 }

--- a/src/services/CodeHost.ts
+++ b/src/services/CodeHost.ts
@@ -1,11 +1,20 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import type * as Option from "effect/Option";
 import type { CodeHostError, PullMeta, PullRef } from "../domain/model.ts";
 
 export type Provider = "github" | "gitlab";
 
 export interface Capabilities {
   readonly adminMerge: boolean;
+}
+
+export interface ReplayBase {
+  readonly branch: string;
+  readonly currentBase: string;
+  readonly head: string;
+  readonly fetchRef: string;
+  readonly change: number;
 }
 
 export interface Interface {
@@ -23,6 +32,10 @@ export interface Interface {
   readonly wait: (pr: number) => Effect.Effect<void, CodeHostError>;
   readonly changes: () => Effect.Effect<ReadonlyArray<PullRef>, CodeHostError>;
   readonly change: (number: number) => Effect.Effect<PullMeta, CodeHostError>;
+  readonly replayBase: (
+    number: number,
+    currentBase: string,
+  ) => Effect.Effect<Option.Option<ReplayBase>, CodeHostError>;
   readonly edit: (pr: number, base: string) => Effect.Effect<void, CodeHostError>;
   readonly body: (pr: number, body: string) => Effect.Effect<void, CodeHostError>;
   readonly close: (pr: number) => Effect.Effect<void, CodeHostError>;

--- a/src/services/CodeHost.ts
+++ b/src/services/CodeHost.ts
@@ -9,13 +9,24 @@ export interface Capabilities {
   readonly adminMerge: boolean;
 }
 
-export interface ReplayBase {
+export interface ReplayForcePushBoundary {
+  readonly kind: "force-push-boundary";
+  readonly currentBase: string;
+  readonly before: string;
+  readonly semanticHead: string;
+  readonly boundary: string;
+}
+
+export interface ReplayMergedParent {
+  readonly kind: "merged-parent";
   readonly branch: string;
   readonly currentBase: string;
   readonly head: string;
   readonly fetchRef: string;
   readonly change: number;
 }
+
+export type ReplayBase = ReplayForcePushBoundary | ReplayMergedParent;
 
 export interface Interface {
   readonly provider: Provider;

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -14,6 +14,11 @@ export interface Worktree {
   readonly dirty: ReadonlyArray<string>;
 }
 
+export interface SemanticCommits {
+  readonly commits: ReadonlyArray<string>;
+  readonly matchedParentPrefix: number;
+}
+
 export interface Interface {
   readonly dirty: () => Effect.Effect<ReadonlyArray<string>, ExecError>;
   readonly worktrees: () => Effect.Effect<ReadonlyArray<Worktree>, ExecError>;
@@ -35,6 +40,11 @@ export interface Interface {
     from: string,
     branch: string,
   ) => Effect.Effect<ReadonlyArray<string>, ExecError>;
+  readonly semanticCommits: (
+    anchor: string,
+    parent: string,
+    branch: string,
+  ) => Effect.Effect<SemanticCommits, ExecError>;
   readonly novel: (
     parent: string,
     branch: string,
@@ -51,6 +61,10 @@ export interface Interface {
   readonly drop: (branch: string) => Effect.Effect<void, ExecError>;
   readonly restore: (branch: string, name: string) => Effect.Effect<void, ExecError>;
   readonly push: (branch: string, remote?: string) => Effect.Effect<void, ExecError>;
+  readonly remoteHead: (
+    remote: string,
+    branch: string,
+  ) => Effect.Effect<Option.Option<string>, ExecError>;
 }
 
 export class Service extends Context.Service<Service, Interface>()("@stack/Git") {}
@@ -218,6 +232,38 @@ export const live = Layer.effect(
         `${from}..${branch}`,
       ]).pipe(Effect.map((out) => out.split("\n").filter(Boolean))),
     );
+    const semanticCommits = Effect.fn("Git.semanticCommits")(function* (
+      anchor: string,
+      parent: string,
+      branch: string,
+    ) {
+      const childCommits = yield* commits(anchor, branch);
+      if (childCommits.length === 0) {
+        return { commits: childCommits, matchedParentPrefix: 0 };
+      }
+
+      const rangeDiff = yield* run("git", [
+        "range-diff",
+        "--no-color",
+        "--no-patch",
+        `${anchor}..${parent}`,
+        `${anchor}..${branch}`,
+      ]);
+      const matched = new Set<number>();
+      for (const line of rangeDiff.split("\n")) {
+        const columns = line.match(/^\s*(\d+|-):\s+\S+\s+([<>=!])\s+(\d+|-):/);
+        if (!columns || columns[1] === "-" || columns[3] === "-") continue;
+        if (columns[2] !== "=" && columns[2] !== "!") continue;
+        matched.add(Number(columns[3]));
+      }
+
+      let matchedParentPrefix = 0;
+      while (matched.has(matchedParentPrefix + 1)) matchedParentPrefix += 1;
+      return {
+        commits: childCommits.slice(matchedParentPrefix),
+        matchedParentPrefix,
+      };
+    });
     const novel = Effect.fn("Git.novel")((
       parent: string,
       branch: string,
@@ -338,6 +384,14 @@ export const live = Layer.effect(
             Effect.asVoid,
           ),
     );
+    const remoteHead = Effect.fn("Git.remoteHead")((remote: string, branch: string) =>
+      run("git", ["ls-remote", "--heads", remote, `refs/heads/${branch}`]).pipe(
+        Effect.map((out) => {
+          const value = out.split(/\s+/, 1)[0];
+          return value ? Option.some(value) : Option.none<string>();
+        }),
+      ),
+    );
     return Service.of({
       fetch,
       remotes,
@@ -350,6 +404,7 @@ export const live = Layer.effect(
       head,
       base,
       commits,
+      semanticCommits,
       novel,
       replay,
       unmergedPaths,
@@ -358,6 +413,7 @@ export const live = Layer.effect(
       drop,
       restore,
       push,
+      remoteHead,
     });
   }),
 );
@@ -391,6 +447,8 @@ export const test = (opts: {
       base: (branch: string, parent: string) =>
         Effect.succeed(Option.fromNullishOr(opts.bases?.[`${branch}:${parent}`])),
       commits: () => Effect.succeed([]),
+      semanticCommits: (_anchor, _parent, _branch) =>
+        Effect.succeed({ commits: [], matchedParentPrefix: 0 }),
       novel: (_parent, _branch, commits) => Effect.succeed(commits),
       replay: () => Effect.void,
       unmergedPaths: () => Effect.succeed([] as ReadonlyArray<string>),
@@ -399,6 +457,8 @@ export const test = (opts: {
       drop: () => Effect.void,
       restore: () => Effect.void,
       push: () => Effect.void,
+      remoteHead: (_remote, branch) =>
+        Effect.succeed(Option.fromNullishOr(opts.refs?.find((ref) => ref.name === branch)?.head)),
     }),
   );
 

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -23,6 +23,7 @@ export interface Interface {
   readonly dirty: () => Effect.Effect<ReadonlyArray<string>, ExecError>;
   readonly worktrees: () => Effect.Effect<ReadonlyArray<Worktree>, ExecError>;
   readonly fetch: () => Effect.Effect<void, ExecError>;
+  readonly fetchRef: (ref: string) => Effect.Effect<string, ExecError>;
   readonly remotes: () => Effect.Effect<
     ReadonlyArray<{ readonly name: string; readonly url: string }>,
     ExecError
@@ -201,6 +202,10 @@ export const live = Layer.effect(
     const fetch = Effect.fn("Git.fetch")(() =>
       run("git", ["fetch", "origin", "--prune"]).pipe(Effect.asVoid),
     );
+    const fetchRef = Effect.fn("Git.fetchRef")(function* (ref: string) {
+      yield* run("git", ["fetch", "origin", "--no-tags", ref]);
+      return yield* run("git", ["rev-parse", "FETCH_HEAD"]);
+    });
     const remotes = Effect.fn("Git.remotes")(() =>
       run("git", ["config", "--get-regexp", "^remote\\..*\\.(push)?url$"], [0, 1]).pipe(
         Effect.map((out) => {
@@ -394,6 +399,7 @@ export const live = Layer.effect(
     );
     return Service.of({
       fetch,
+      fetchRef,
       remotes,
       dirty,
       worktrees,
@@ -428,6 +434,7 @@ export const test = (opts: {
     Service,
     Service.of({
       fetch: () => Effect.void,
+      fetchRef: (ref) => Effect.succeed(opts.refs?.find((item) => item.name === ref)?.head ?? ref),
       dirty: () => Effect.succeed([]),
       worktrees: () => Effect.succeed([]),
       refs: () => Effect.succeed(opts.refs ?? []),

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -61,7 +61,11 @@ export interface Interface {
   readonly backup: (branch: string, name: string) => Effect.Effect<void, ExecError>;
   readonly drop: (branch: string) => Effect.Effect<void, ExecError>;
   readonly restore: (branch: string, name: string) => Effect.Effect<void, ExecError>;
-  readonly push: (branch: string, remote?: string) => Effect.Effect<void, ExecError>;
+  readonly push: (
+    branch: string,
+    remote?: string,
+    expectedHead?: string | null,
+  ) => Effect.Effect<void, ExecError>;
   readonly remoteHead: (
     remote: string,
     branch: string,
@@ -382,14 +386,22 @@ export const live = Layer.effect(
     const restore = Effect.fn("Git.restore")((branch: string, name: string) =>
       run("git", ["branch", "-f", branch, name]).pipe(Effect.asVoid),
     );
-    const push = Effect.fn("Git.push")((branch: string, remote = "origin") =>
-      remote === "origin"
-        ? run("git", ["push", "--force-with-lease", "-u", remote, branch]).pipe(Effect.asVoid)
+    const push = Effect.fn("Git.push")((
+      branch: string,
+      remote = "origin",
+      expectedHead?: string | null,
+    ) => {
+      const lease =
+        expectedHead === undefined
+          ? "--force-with-lease"
+          : `--force-with-lease=refs/heads/${branch}:${expectedHead ?? ""}`;
+      return remote === "origin"
+        ? run("git", ["push", lease, "-u", remote, branch]).pipe(Effect.asVoid)
         : run("git", ["fetch", remote, "--prune"]).pipe(
-            Effect.flatMap(() => run("git", ["push", "--force-with-lease", remote, branch])),
+            Effect.flatMap(() => run("git", ["push", lease, remote, branch])),
             Effect.asVoid,
-          ),
-    );
+          );
+    });
     const remoteHead = Effect.fn("Git.remoteHead")((remote: string, branch: string) =>
       run("git", ["ls-remote", "--heads", remote, `refs/heads/${branch}`]).pipe(
         Effect.map((out) => {

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -249,21 +249,22 @@ export const live = Layer.effect(
 
       const rangeDiff = yield* run("git", [
         "range-diff",
+        "--abbrev=40",
         "--no-color",
         "--no-patch",
         `${anchor}..${parent}`,
         `${anchor}..${branch}`,
       ]);
-      const matched = new Set<number>();
+      const matched = new Set<string>();
       for (const line of rangeDiff.split("\n")) {
-        const columns = line.match(/^\s*(\d+|-):\s+\S+\s+([<>=!])\s+(\d+|-):/);
+        const columns = line.match(/^\s*(\d+|-):\s+\S+\s+([<>=!])\s+(\d+|-):\s+(\S+)/);
         if (!columns || columns[1] === "-" || columns[3] === "-") continue;
         if (columns[2] !== "=" && columns[2] !== "!") continue;
-        matched.add(Number(columns[3]));
+        matched.add(columns[4]!);
       }
 
       let matchedParentPrefix = 0;
-      while (matched.has(matchedParentPrefix + 1)) matchedParentPrefix += 1;
+      while (matched.has(childCommits[matchedParentPrefix]!)) matchedParentPrefix += 1;
       return {
         commits: childCommits.slice(matchedParentPrefix),
         matchedParentPrefix,

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -224,7 +224,7 @@ export const live = Layer.effect(
       ),
     );
     const head = Effect.fn("Git.head")((name: string) =>
-      run("git", ["rev-parse", "--verify", name], [0, 1]).pipe(
+      run("git", ["rev-parse", "--verify", `${name}^{commit}`], [0, 1, 128]).pipe(
         Effect.map((out) => (out ? Option.some(out) : Option.none<string>())),
       ),
     );

--- a/src/services/Git.ts
+++ b/src/services/Git.ts
@@ -41,6 +41,7 @@ export interface Interface {
     from: string,
     branch: string,
   ) => Effect.Effect<ReadonlyArray<string>, ExecError>;
+  readonly mergeParents: (branch: string) => Effect.Effect<ReadonlyArray<string>, ExecError>;
   readonly semanticCommits: (
     anchor: string,
     parent: string,
@@ -241,6 +242,16 @@ export const live = Layer.effect(
         `${from}..${branch}`,
       ]).pipe(Effect.map((out) => out.split("\n").filter(Boolean))),
     );
+    const mergeParents = Effect.fn("Git.mergeParents")((branch: string) =>
+      run("git", ["rev-list", "--first-parent", "--merges", "--parents", branch]).pipe(
+        Effect.map((out) =>
+          out
+            .split("\n")
+            .filter(Boolean)
+            .flatMap((line) => line.split(" ").slice(2)),
+        ),
+      ),
+    );
     const semanticCommits = Effect.fn("Git.semanticCommits")(function* (
       anchor: string,
       parent: string,
@@ -423,6 +434,7 @@ export const live = Layer.effect(
       head,
       base,
       commits,
+      mergeParents,
       semanticCommits,
       novel,
       replay,
@@ -467,6 +479,7 @@ export const test = (opts: {
       base: (branch: string, parent: string) =>
         Effect.succeed(Option.fromNullishOr(opts.bases?.[`${branch}:${parent}`])),
       commits: () => Effect.succeed([]),
+      mergeParents: () => Effect.succeed([]),
       semanticCommits: (_anchor, _parent, _branch) =>
         Effect.succeed({ commits: [], matchedParentPrefix: 0 }),
       novel: (_parent, _branch, commits) => Effect.succeed(commits),

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -938,6 +938,13 @@ ${note}`;
                   }
                 }
               }
+              if (trunk(parent) && candidates.length === 0 && all.length > 1) {
+                return yield* Effect.fail(
+                  new StackOperationError(
+                    `semantic replay boundary required for ${branch}: no durable code-host lineage is available; refusing to replay ${all.length} commits from persisted anchor ${anchor}`,
+                  ),
+                );
+              }
               let selected = all;
               let matchedParentPrefix = 0;
 

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -893,15 +893,49 @@ ${note}`;
               if (!savedParent && trunk(parent) && link.pr) {
                 const recovered = yield* codeHost.replayBase(Number(link.pr), parent);
                 if (Option.isSome(recovered)) {
-                  const fetchedHead = yield* git.fetchRef(recovered.value.fetchRef);
-                  if (fetchedHead !== recovered.value.head) {
-                    return yield* Effect.fail(
-                      new StackOperationError(
-                        `fetched ${recovered.value.fetchRef} at ${fetchedHead}, expected ${recovered.value.head}`,
-                      ),
-                    );
+                  if (recovered.value.kind === "force-push-boundary") {
+                    const { boundary, semanticHead } = recovered.value;
+                    const [
+                      boundaryHead,
+                      semanticHeadRef,
+                      embeddedAnchor,
+                      embeddedBoundary,
+                      embeddedSemanticHead,
+                    ] = yield* Effect.all([
+                      git.head(boundary),
+                      git.head(semanticHead),
+                      git.base(branch, anchor),
+                      git.base(semanticHead, boundary),
+                      git.base(branch, semanticHead),
+                    ]);
+                    if (
+                      Option.isNone(boundaryHead) ||
+                      Option.isNone(semanticHeadRef) ||
+                      Option.isNone(embeddedAnchor) ||
+                      embeddedAnchor.value !== anchor ||
+                      Option.isNone(embeddedBoundary) ||
+                      embeddedBoundary.value !== boundary ||
+                      Option.isNone(embeddedSemanticHead) ||
+                      embeddedSemanticHead.value !== semanticHead
+                    ) {
+                      return yield* Effect.fail(
+                        new StackOperationError(
+                          `cannot verify force-push replay boundary ${boundary} -> ${semanticHead} for ${branch}`,
+                        ),
+                      );
+                    }
+                    return yield* git.novel(onto, branch, yield* git.commits(boundary, branch));
+                  } else {
+                    const fetchedHead = yield* git.fetchRef(recovered.value.fetchRef);
+                    if (fetchedHead !== recovered.value.head) {
+                      return yield* Effect.fail(
+                        new StackOperationError(
+                          `fetched ${recovered.value.fetchRef} at ${fetchedHead}, expected ${recovered.value.head}`,
+                        ),
+                      );
+                    }
+                    candidates.push(recovered.value.head);
                   }
-                  candidates.push(recovered.value.head);
                 }
               }
               let selected = all;

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -883,7 +883,6 @@ ${note}`;
             ) {
               const branch = String(link.branch);
               const anchor = replayAnchors.get(branch) ?? String(link.anchor);
-              const all = yield* git.commits(anchor, branch);
               const savedParent = saved.get(String(link.parent));
               const candidates = savedParent
                 ? [savedParent]
@@ -895,24 +894,16 @@ ${note}`;
                 if (Option.isSome(recovered)) {
                   if (recovered.value.kind === "force-push-boundary") {
                     const { boundary, semanticHead } = recovered.value;
-                    const [
-                      boundaryHead,
-                      semanticHeadRef,
-                      embeddedAnchor,
-                      embeddedBoundary,
-                      embeddedSemanticHead,
-                    ] = yield* Effect.all([
-                      git.head(boundary),
-                      git.head(semanticHead),
-                      git.base(branch, anchor),
-                      git.base(semanticHead, boundary),
-                      git.base(branch, semanticHead),
-                    ]);
+                    const [boundaryHead, semanticHeadRef, embeddedBoundary, embeddedSemanticHead] =
+                      yield* Effect.all([
+                        git.head(boundary),
+                        git.head(semanticHead),
+                        git.base(semanticHead, boundary),
+                        git.base(branch, semanticHead),
+                      ]);
                     if (
                       Option.isNone(boundaryHead) ||
                       Option.isNone(semanticHeadRef) ||
-                      Option.isNone(embeddedAnchor) ||
-                      embeddedAnchor.value !== anchor ||
                       Option.isNone(embeddedBoundary) ||
                       embeddedBoundary.value !== boundary ||
                       Option.isNone(embeddedSemanticHead) ||
@@ -938,6 +929,7 @@ ${note}`;
                   }
                 }
               }
+              const all = yield* git.commits(anchor, branch);
               if (trunk(parent) && candidates.length === 0 && all.length > 1) {
                 return yield* Effect.fail(
                   new StackOperationError(

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -1770,9 +1770,9 @@ ${note}`;
                 new StackOperationError(`--admin is not supported by ${codeHost.provider}`),
               );
             }
-            if (repairDepth !== undefined && (!Number.isInteger(repairDepth) || repairDepth < 1)) {
+            if (repairDepth !== undefined && (!Number.isInteger(repairDepth) || repairDepth < 0)) {
               return yield* Effect.fail(
-                new StackOperationError("--repair-depth must be a positive integer"),
+                new StackOperationError("--repair-depth must be a non-negative integer"),
               );
             }
             const active = apply || auto;

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -49,6 +49,7 @@ export interface StackService {
       readonly auto?: boolean;
       readonly admin?: boolean;
       readonly through?: string;
+      readonly repairDepth?: number;
     },
   ) => Effect.Effect<ReadonlyArray<string>, StackError>;
   readonly sync: (opts?: {
@@ -325,7 +326,11 @@ ${note}`;
         return lines;
       };
 
-      const scopedBranches = (state: ReturnType<typeof stackState>, root: string) => {
+      const scopedBranches = (
+        state: ReturnType<typeof stackState>,
+        root: string,
+        maxDepth?: number,
+      ) => {
         const children = new Map<string, Array<string>>();
         for (const link of state.links) {
           const parent = String(link.parent);
@@ -335,12 +340,13 @@ ${note}`;
         }
 
         const branches = new Set<string>();
-        const visit = (branch: string) => {
+        const visit = (branch: string, depth: number) => {
           if (branches.has(branch)) return;
           branches.add(branch);
-          for (const child of children.get(branch) ?? []) visit(child);
+          if (maxDepth !== undefined && depth >= maxDepth) return;
+          for (const child of children.get(branch) ?? []) visit(child, depth + 1);
         };
-        visit(root);
+        visit(root, 0);
         return branches;
       };
 
@@ -569,7 +575,21 @@ ${note}`;
                 continue;
               }
 
-              const anchor = yield* git.base(branch, parent);
+              let anchor = yield* git.base(branch, parent);
+              if (!trunks.has(parent)) {
+                const remoteParent = `origin/${parent}`;
+                const [remoteHead, remoteBase] = yield* Effect.all([
+                  git.head(remoteParent),
+                  git.base(branch, remoteParent),
+                ]);
+                if (
+                  Option.isSome(remoteHead) &&
+                  Option.isSome(remoteBase) &&
+                  remoteHead.value === remoteBase.value
+                ) {
+                  anchor = remoteHead;
+                }
+              }
               if (Option.isNone(anchor)) continue;
 
               const action = stackLink({
@@ -705,6 +725,7 @@ ${note}`;
               state: ReturnType<typeof stackState>,
             ) => Effect.Effect<void, StackError>;
             readonly preserveUndo?: boolean;
+            readonly preserveTrunkRoots?: boolean;
           },
         ) =>
           Effect.gen(function* () {
@@ -746,7 +767,6 @@ ${note}`;
             const childBases = new Set(pulls.map((pull) => String(pull.base)));
             let remoteByRepository: Map<string, string> | null = null;
             const tips = new Map<string, string | null>();
-            const prior = new Map<string, string>();
             const moved = new Set<string>();
             const entries: Array<UndoEntry> = Array.from(opts.initialEntries ?? []);
             const next: Array<StackLink> = [];
@@ -785,24 +805,6 @@ ${note}`;
               if (childBases.has(branch)) remotes.add("origin");
               return [...remotes];
             });
-
-            const backups = refs
-              .map((ref) => ref.name)
-              .filter(
-                (name) =>
-                  name.startsWith("backup/landed-") || name.startsWith("backup/stack-sync-"),
-              )
-              .sort();
-            const landedBackupHeads = new Set(
-              refs
-                .filter((ref) => ref.name.startsWith("backup/landed-"))
-                .map((ref) => String(ref.head)),
-            );
-            for (const name of backups) {
-              for (const link of state.links) {
-                if (name.endsWith(`-${link.branch}`)) prior.set(String(link.branch), name);
-              }
-            }
 
             const checkpoint = Effect.fn("Stack.repairStack.checkpoint")(() =>
               apply
@@ -903,22 +905,21 @@ ${note}`;
 
               const pr = prs.get(String(link.branch)) ?? null;
               const onto = trunk(parent) ? `origin/${parent}` : parent;
-              const from =
-                saved.get(String(link.parent)) ??
-                (live.has(String(link.parent))
-                  ? String(link.parent)
-                  : (prior.get(String(link.parent)) ?? String(link.parent)));
               if (!tips.has(onto)) {
                 const tip = yield* git.head(onto);
                 tips.set(onto, Option.isSome(tip) ? tip.value : null);
               }
               const want = tips.get(onto) ?? heads.get(parent) ?? null;
               const have = yield* git.base(link.branch, onto);
+              const ancestryDrift =
+                !(trunk(parent) && opts.preserveTrunkRoots === true) &&
+                want &&
+                (Option.isNone(have) || have.value !== want);
               const drift =
                 replayAnchors.has(String(link.branch)) ||
                 parent !== link.parent ||
                 (!apply && moved.has(parent)) ||
-                (want && (Option.isNone(have) || have.value !== want));
+                ancestryDrift;
               const base = pr?.base ?? null;
               let backup: string | null = null;
               let created: number | null = null;
@@ -942,12 +943,8 @@ ${note}`;
                   headRepository,
                   pr ? Number(pr.number) : link.pr ? Number(link.pr) : null,
                 );
-                const landedAnchor =
-                  trunk(parent) && landedBackupHeads.has(String(link.anchor))
-                    ? String(link.anchor)
-                    : null;
-                const anchor = replayAnchors.get(String(link.branch)) ?? landedAnchor;
-                const baseRef = anchor ? Option.some(anchor) : yield* git.base(link.branch, from);
+                const anchor = replayAnchors.get(String(link.branch)) ?? String(link.anchor);
+                const baseRef = Option.some(anchor);
                 const commitsToReplay = Option.isSome(baseRef)
                   ? yield* Effect.gen(function* () {
                       const commits = yield* git.commits(baseRef.value, link.branch);
@@ -1236,6 +1233,10 @@ ${note}`;
                     initialActions: scopedInitial,
                     ...(writeState ? { writeState } : {}),
                     preserveUndo,
+                    preserveTrunkRoots:
+                      requestedBranch !== undefined &&
+                      target !== null &&
+                      requestedBranch !== target.root,
                   });
                   const changedOpenPulls = repair.actions.some(
                     (action) => action._tag === "RetargetPull" || action._tag === "CreatePull",
@@ -1597,12 +1598,14 @@ ${note}`;
             readonly auto?: boolean;
             readonly admin?: boolean;
             readonly through?: string;
+            readonly repairDepth?: number;
           },
         ) =>
           Effect.gen(function* () {
             const apply = opts?.apply ?? false;
             const auto = opts?.auto ?? false;
             const admin = opts?.admin ?? false;
+            const repairDepth = opts?.repairDepth;
             if (apply && auto) {
               return yield* Effect.fail(
                 new StackOperationError("use either --apply or --auto, not both"),
@@ -1614,6 +1617,11 @@ ${note}`;
             if (admin && !codeHost.capabilities.adminMerge) {
               return yield* Effect.fail(
                 new StackOperationError(`--admin is not supported by ${codeHost.provider}`),
+              );
+            }
+            if (repairDepth !== undefined && (!Number.isInteger(repairDepth) || repairDepth < 1)) {
+              return yield* Effect.fail(
+                new StackOperationError("--repair-depth must be a positive integer"),
               );
             }
             const active = apply || auto;
@@ -1638,7 +1646,7 @@ ${note}`;
               );
             }
 
-            const branches = scopedBranches(state, target);
+            const branches = scopedBranches(state, target, repairDepth);
             const scopedState = filterState(state, branches);
 
             const pr = yield* changeForLink(link, pulls);
@@ -1871,7 +1879,12 @@ ${note}`;
 
           for (const target of chain) {
             if (items.length > 0) items.push("");
-            items.push(...(yield* landOne(target, { auto: true })));
+            items.push(
+              ...(yield* landOne(target, {
+                auto: true,
+                ...(opts.repairDepth === undefined ? {} : { repairDepth: opts.repairDepth }),
+              })),
+            );
           }
 
           items.push(`merged through: ${stop}`);

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -197,6 +197,7 @@ ${note}`;
         readonly pulls: ReadonlyArray<PullRef>;
         readonly actions: ReadonlyArray<StackResult.StackResultItem>;
         readonly mode: StackResult.Mode;
+        readonly applyCommand?: string;
         readonly failed?: { readonly branch: string; readonly parent: string };
       }) => {
         const trunkNames = cfg.trunks.map(String);
@@ -319,8 +320,9 @@ ${note}`;
         }
         if (backups > 0 && opts.mode === "apply") summary.push(`Backups created: ${backups}`);
         if (summary.length > 0) lines.push("", ...summary);
-        if (opts.mode === "dry-run") lines.push("", "Apply:", "  stack sync --apply");
-        else if (!opts.failed && (backups > 0 || updatedPrs.size > 0)) {
+        if (opts.mode === "dry-run") {
+          lines.push("", "Apply:", `  ${opts.applyCommand ?? "stack sync --apply"}`);
+        } else if (!opts.failed && (backups > 0 || updatedPrs.size > 0)) {
           lines.push("", "Undo:", "  stack undo --apply");
         }
         return lines;
@@ -1272,6 +1274,9 @@ ${note}`;
                   );
                   const notes = yield* linksFor(repair.state, !dryRun, new Set(), notesPulls);
                   const changed = repair.actions.length > 0 || notes.actions.length > 0;
+                  const applyCommand = requestedBranch
+                    ? `stack sync ${requestedBranch} --apply`
+                    : "stack sync --apply";
                   const lines = !changed
                     ? renderSyncTree({
                         title: "Stack is current",
@@ -1279,6 +1284,7 @@ ${note}`;
                         pulls: scopedPulls,
                         actions: [],
                         mode,
+                        applyCommand,
                       })
                     : renderSyncTree({
                         title: dryRun ? "Sync preview" : "Synced stack",
@@ -1286,6 +1292,7 @@ ${note}`;
                         pulls: scopedPulls,
                         actions: [...repair.actions, ...notes.actions],
                         mode,
+                        applyCommand,
                       });
                   return { lines, undo: repair.undo };
                 }),

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -933,6 +933,7 @@ ${note}`;
               const all = yield* git.commits(anchor, branch);
               let selected = all;
               let matchedParentPrefix = 0;
+              let savedParentBoundaryVerified = false;
 
               for (const candidate of candidates) {
                 const [candidateHead, embeddedAnchor, embeddedCandidate] = yield* Effect.all([
@@ -947,6 +948,17 @@ ${note}`;
                   embeddedAnchor.value !== anchor
                 )
                   continue;
+                const preservedMergeParents =
+                  candidate === savedParent ? yield* git.mergeParents(candidate) : [];
+                if (
+                  candidate === savedParent &&
+                  Option.isSome(embeddedCandidate) &&
+                  embeddedCandidate.value === anchor &&
+                  preservedMergeParents.includes(anchor)
+                ) {
+                  savedParentBoundaryVerified = true;
+                  break;
+                }
                 let semantic;
                 if (Option.isSome(embeddedCandidate) && embeddedCandidate.value === candidate) {
                   const commits = yield* git.commits(candidate, branch);
@@ -962,7 +974,12 @@ ${note}`;
                 matchedParentPrefix = semantic.matchedParentPrefix;
               }
 
-              if (trunk(parent) && all.length > 1 && matchedParentPrefix === 0) {
+              if (
+                trunk(parent) &&
+                all.length > 1 &&
+                matchedParentPrefix === 0 &&
+                !savedParentBoundaryVerified
+              ) {
                 return yield* Effect.fail(
                   new StackOperationError(
                     `semantic replay boundary required for ${branch}: durable code-host lineage did not match the persisted range; refusing to replay ${all.length} commits from persisted anchor ${anchor}`,

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -813,6 +813,9 @@ ${note}`;
               );
             }
             const childBases = new Set(pulls.map((pull) => String(pull.base)));
+            const landedBackups = refs
+              .map((ref) => String(ref.name))
+              .filter((name) => name.startsWith("backup/landed-"));
             let remoteByRepository: Map<string, string> | null = null;
             const tips = new Map<string, string | null>();
             const moved = new Set<string>();
@@ -872,6 +875,40 @@ ${note}`;
             );
 
             if (journal) yield* checkpoint();
+
+            const commitsForReplay = Effect.fn("Stack.repairStack.commitsForReplay")(function* (
+              link: StackLink,
+              parent: string,
+              onto: string,
+            ) {
+              const branch = String(link.branch);
+              const anchor = replayAnchors.get(branch) ?? String(link.anchor);
+              const all = yield* git.commits(anchor, branch);
+              const savedParent = saved.get(String(link.parent));
+              const candidates = savedParent ? [savedParent] : trunk(parent) ? landedBackups : [];
+              let selected = all;
+              let matchedParentPrefix = 0;
+
+              for (const candidate of candidates) {
+                const [candidateHead, embeddedAnchor] = yield* Effect.all([
+                  git.head(candidate),
+                  git.base(candidate, anchor),
+                ]);
+                if (
+                  Option.isNone(candidateHead) ||
+                  candidateHead.value === anchor ||
+                  Option.isNone(embeddedAnchor) ||
+                  embeddedAnchor.value !== anchor
+                )
+                  continue;
+                const semantic = yield* git.semanticCommits(anchor, candidate, branch);
+                if (semantic.matchedParentPrefix <= matchedParentPrefix) continue;
+                selected = semantic.commits;
+                matchedParentPrefix = semantic.matchedParentPrefix;
+              }
+
+              return yield* git.novel(onto, branch, selected);
+            });
 
             const resolve = (name: string, seen = new Set<string>()): string | null => {
               let parent = name;
@@ -991,14 +1028,7 @@ ${note}`;
                   headRepository,
                   pr ? Number(pr.number) : link.pr ? Number(link.pr) : null,
                 );
-                const anchor = replayAnchors.get(String(link.branch)) ?? String(link.anchor);
-                const baseRef = Option.some(anchor);
-                const commitsToReplay = Option.isSome(baseRef)
-                  ? yield* Effect.gen(function* () {
-                      const commits = yield* git.commits(baseRef.value, link.branch);
-                      return yield* git.novel(onto, link.branch, commits);
-                    })
-                  : Array<string>();
+                const commitsToReplay = yield* commitsForReplay(link, parent, onto);
                 backup = `backup/stack-sync-${stamp}-${link.branch}`;
                 const rebase = {
                   branch: String(link.branch),
@@ -1008,7 +1038,8 @@ ${note}`;
                   commits: commitsToReplay,
                   pushRemotes: targetRemotes,
                 } satisfies RepairPlan.RebaseBranchPlan;
-                actions.push(...RepairPlan.rebaseBranch(rebase, mode));
+                const rebaseActions = RepairPlan.rebaseBranch(rebase, mode);
+                if (!apply) actions.push(...rebaseActions);
 
                 if (apply) {
                   const priorEntry = entries.find((item) => item.branch === link.branch) ?? null;
@@ -1027,6 +1058,10 @@ ${note}`;
                   yield* RepairExecution.applyRebaseBranch(rebase, {
                     git,
                     checkpoint,
+                    complete: (item) => {
+                      actions.push(item);
+                      return checkpoint();
+                    },
                     step,
                     onReplayFailure: (err) => replayFailure(rebase, err, state, pulls, actions),
                   });
@@ -1820,7 +1855,7 @@ ${note}`;
               scopedState,
               refs.filter((item) => item.name !== target),
               repairPulls,
-              { apply: false },
+              { apply: false, saved: new Map([[target, target]]) },
             );
             if (active) {
               yield* ensureRepairableWorktrees([

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -883,6 +883,19 @@ ${note}`;
             ) {
               const branch = String(link.branch);
               const anchor = replayAnchors.get(branch) ?? String(link.anchor);
+              const anchorHead = yield* git.head(anchor);
+              let persistedAnchorIsSharedBase = false;
+              if (Option.isSome(anchorHead)) {
+                const [anchorInBranch, anchorInTarget] = yield* Effect.all([
+                  git.base(branch, anchor),
+                  git.base(onto, anchor),
+                ]);
+                persistedAnchorIsSharedBase =
+                  Option.isSome(anchorInBranch) &&
+                  anchorInBranch.value === anchor &&
+                  Option.isSome(anchorInTarget) &&
+                  anchorInTarget.value === anchor;
+              }
               const savedParent = saved.get(String(link.parent));
               const candidates = savedParent
                 ? [savedParent]
@@ -893,6 +906,10 @@ ${note}`;
                 const recovered = yield* codeHost.replayBase(Number(link.pr), parent);
                 if (Option.isSome(recovered)) {
                   if (recovered.value.kind === "force-push-boundary") {
+                    if (persistedAnchorIsSharedBase) {
+                      const all = yield* git.commits(anchor, branch);
+                      return yield* git.novel(onto, branch, all);
+                    }
                     const { boundary, semanticHead } = recovered.value;
                     const [boundaryHead, semanticHeadRef, embeddedBoundary, embeddedSemanticHead] =
                       yield* Effect.all([
@@ -930,7 +947,12 @@ ${note}`;
                 }
               }
               const all = yield* git.commits(anchor, branch);
-              if (trunk(parent) && candidates.length === 0 && all.length > 1) {
+              if (
+                trunk(parent) &&
+                candidates.length === 0 &&
+                all.length > 1 &&
+                !persistedAnchorIsSharedBase
+              ) {
                 return yield* Effect.fail(
                   new StackOperationError(
                     `semantic replay boundary required for ${branch}: no durable code-host lineage is available; refusing to replay ${all.length} commits from persisted anchor ${anchor}`,

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -685,6 +685,31 @@ ${note}`;
                   continue;
                 }
               }
+              if (!trunks.has(parent) && refNames.has(parent)) {
+                const [parentHead, embeddedParent] = yield* Effect.all([
+                  git.head(parent),
+                  git.base(branch, parent),
+                ]);
+                if (
+                  Option.isSome(parentHead) &&
+                  Option.isSome(embeddedParent) &&
+                  parentHead.value === embeddedParent.value &&
+                  link.anchor !== embeddedParent.value
+                ) {
+                  reconciled.push(
+                    stackLink({
+                      branch,
+                      parent,
+                      anchor: embeddedParent.value,
+                      pr: link.pr,
+                      ...(link.headRepository !== undefined
+                        ? { headRepository: link.headRepository }
+                        : {}),
+                    }),
+                  );
+                  continue;
+                }
+              }
               reconciled.push(link);
             }
 

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -883,19 +883,6 @@ ${note}`;
             ) {
               const branch = String(link.branch);
               const anchor = replayAnchors.get(branch) ?? String(link.anchor);
-              const anchorHead = yield* git.head(anchor);
-              let persistedAnchorIsSharedBase = false;
-              if (Option.isSome(anchorHead)) {
-                const [anchorInBranch, anchorInTarget] = yield* Effect.all([
-                  git.base(branch, anchor),
-                  git.base(onto, anchor),
-                ]);
-                persistedAnchorIsSharedBase =
-                  Option.isSome(anchorInBranch) &&
-                  anchorInBranch.value === anchor &&
-                  Option.isSome(anchorInTarget) &&
-                  anchorInTarget.value === anchor;
-              }
               const savedParent = saved.get(String(link.parent));
               const candidates = savedParent
                 ? [savedParent]
@@ -906,10 +893,6 @@ ${note}`;
                 const recovered = yield* codeHost.replayBase(Number(link.pr), parent);
                 if (Option.isSome(recovered)) {
                   if (recovered.value.kind === "force-push-boundary") {
-                    if (persistedAnchorIsSharedBase) {
-                      const all = yield* git.commits(anchor, branch);
-                      return yield* git.novel(onto, branch, all);
-                    }
                     const { boundary, semanticHead } = recovered.value;
                     const [boundaryHead, semanticHeadRef, embeddedBoundary, embeddedSemanticHead] =
                       yield* Effect.all([
@@ -943,29 +926,19 @@ ${note}`;
                       );
                     }
                     candidates.push(recovered.value.head);
+                    candidates.push(...recovered.value.historicalHeads);
                   }
                 }
               }
               const all = yield* git.commits(anchor, branch);
-              if (
-                trunk(parent) &&
-                candidates.length === 0 &&
-                all.length > 1 &&
-                !persistedAnchorIsSharedBase
-              ) {
-                return yield* Effect.fail(
-                  new StackOperationError(
-                    `semantic replay boundary required for ${branch}: no durable code-host lineage is available; refusing to replay ${all.length} commits from persisted anchor ${anchor}`,
-                  ),
-                );
-              }
               let selected = all;
               let matchedParentPrefix = 0;
 
               for (const candidate of candidates) {
-                const [candidateHead, embeddedAnchor] = yield* Effect.all([
+                const [candidateHead, embeddedAnchor, embeddedCandidate] = yield* Effect.all([
                   git.head(candidate),
                   git.base(candidate, anchor),
+                  git.base(branch, candidate),
                 ]);
                 if (
                   Option.isNone(candidateHead) ||
@@ -974,10 +947,27 @@ ${note}`;
                   embeddedAnchor.value !== anchor
                 )
                   continue;
-                const semantic = yield* git.semanticCommits(anchor, candidate, branch);
+                let semantic;
+                if (Option.isSome(embeddedCandidate) && embeddedCandidate.value === candidate) {
+                  const commits = yield* git.commits(candidate, branch);
+                  semantic = {
+                    commits,
+                    matchedParentPrefix: all.length - commits.length,
+                  };
+                } else {
+                  semantic = yield* git.semanticCommits(anchor, candidate, branch);
+                }
                 if (semantic.matchedParentPrefix <= matchedParentPrefix) continue;
                 selected = semantic.commits;
                 matchedParentPrefix = semantic.matchedParentPrefix;
+              }
+
+              if (trunk(parent) && all.length > 1 && matchedParentPrefix === 0) {
+                return yield* Effect.fail(
+                  new StackOperationError(
+                    `semantic replay boundary required for ${branch}: durable code-host lineage did not match the persisted range; refusing to replay ${all.length} commits from persisted anchor ${anchor}`,
+                  ),
+                );
               }
 
               return yield* git.novel(onto, branch, selected);

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -885,7 +885,25 @@ ${note}`;
               const anchor = replayAnchors.get(branch) ?? String(link.anchor);
               const all = yield* git.commits(anchor, branch);
               const savedParent = saved.get(String(link.parent));
-              const candidates = savedParent ? [savedParent] : trunk(parent) ? landedBackups : [];
+              const candidates = savedParent
+                ? [savedParent]
+                : trunk(parent)
+                  ? Array.from(landedBackups)
+                  : [];
+              if (!savedParent && trunk(parent) && link.pr) {
+                const recovered = yield* codeHost.replayBase(Number(link.pr), parent);
+                if (Option.isSome(recovered)) {
+                  const fetchedHead = yield* git.fetchRef(recovered.value.fetchRef);
+                  if (fetchedHead !== recovered.value.head) {
+                    return yield* Effect.fail(
+                      new StackOperationError(
+                        `fetched ${recovered.value.fetchRef} at ${fetchedHead}, expected ${recovered.value.head}`,
+                      ),
+                    );
+                  }
+                  candidates.push(recovered.value.head);
+                }
+              }
               let selected = all;
               let matchedParentPrefix = 0;
 

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -40,7 +40,11 @@ import { Store } from "./Store.ts";
 
 export interface StackService {
   readonly status: () => Effect.Effect<StatusReport, StackError>;
-  readonly adopt: (branch: string, parent: string) => Effect.Effect<StackLink, StackError>;
+  readonly adopt: (
+    branch: string,
+    parent: string,
+    anchor?: string,
+  ) => Effect.Effect<StackLink, StackError>;
   readonly links: (apply?: boolean) => Effect.Effect<ReadonlyArray<string>, StackError>;
   readonly land: (
     branch?: string,
@@ -468,7 +472,7 @@ ${note}`;
         return ["", "Stack", renderDiagram(scopedReport, reference)];
       });
 
-      const adopt = Effect.fn("Stack.adopt")((branch: string, parent: string) =>
+      const adopt = Effect.fn("Stack.adopt")((branch: string, parent: string, anchor?: string) =>
         Effect.gen(function* () {
           const refs = yield* git.refs();
           if (trunk(branch)) {
@@ -489,6 +493,23 @@ ${note}`;
 
           const base = yield* git.base(branch, parent);
           if (Option.isNone(base)) return yield* Effect.fail(new MergeBaseError(branch, parent));
+          let replayAnchor = base.value;
+          if (anchor !== undefined) {
+            const [anchorHead, embeddedAnchor] = yield* Effect.all([
+              git.head(anchor),
+              git.base(branch, anchor),
+            ]);
+            if (
+              Option.isNone(anchorHead) ||
+              Option.isNone(embeddedAnchor) ||
+              anchorHead.value !== embeddedAnchor.value
+            ) {
+              return yield* Effect.fail(
+                new StackOperationError(`${anchor} is not an ancestor of ${branch}`),
+              );
+            }
+            replayAnchor = anchorHead.value;
+          }
 
           const [state, pulls] = yield* Effect.all([store.read(), codeHost.changes()]);
           const nextLinks = new Map(
@@ -516,7 +537,7 @@ ${note}`;
           const next = stackLink({
             branch,
             parent,
-            anchor: base.value,
+            anchor: replayAnchor,
             pr,
             headRepository: pull?.headRepository ?? null,
           });

--- a/src/services/Stack.ts
+++ b/src/services/Stack.ts
@@ -889,32 +889,37 @@ ${note}`;
                 : trunk(parent)
                   ? Array.from(landedBackups)
                   : [];
+              const verifyForcePushBoundary = Effect.fn(
+                "Stack.repairStack.verifyForcePushBoundary",
+              )(function* (boundary: string, semanticHead: string) {
+                const [boundaryHead, semanticHeadRef, embeddedBoundary, embeddedSemanticHead] =
+                  yield* Effect.all([
+                    git.head(boundary),
+                    git.head(semanticHead),
+                    git.base(semanticHead, boundary),
+                    git.base(branch, semanticHead),
+                  ]);
+                if (
+                  Option.isNone(boundaryHead) ||
+                  Option.isNone(semanticHeadRef) ||
+                  Option.isNone(embeddedBoundary) ||
+                  embeddedBoundary.value !== boundary ||
+                  Option.isNone(embeddedSemanticHead) ||
+                  embeddedSemanticHead.value !== semanticHead
+                ) {
+                  return yield* Effect.fail(
+                    new StackOperationError(
+                      `cannot verify force-push replay boundary ${boundary} -> ${semanticHead} for ${branch}`,
+                    ),
+                  );
+                }
+              });
               if (!savedParent && trunk(parent) && link.pr) {
                 const recovered = yield* codeHost.replayBase(Number(link.pr), parent);
                 if (Option.isSome(recovered)) {
                   if (recovered.value.kind === "force-push-boundary") {
                     const { boundary, semanticHead } = recovered.value;
-                    const [boundaryHead, semanticHeadRef, embeddedBoundary, embeddedSemanticHead] =
-                      yield* Effect.all([
-                        git.head(boundary),
-                        git.head(semanticHead),
-                        git.base(semanticHead, boundary),
-                        git.base(branch, semanticHead),
-                      ]);
-                    if (
-                      Option.isNone(boundaryHead) ||
-                      Option.isNone(semanticHeadRef) ||
-                      Option.isNone(embeddedBoundary) ||
-                      embeddedBoundary.value !== boundary ||
-                      Option.isNone(embeddedSemanticHead) ||
-                      embeddedSemanticHead.value !== semanticHead
-                    ) {
-                      return yield* Effect.fail(
-                        new StackOperationError(
-                          `cannot verify force-push replay boundary ${boundary} -> ${semanticHead} for ${branch}`,
-                        ),
-                      );
-                    }
+                    yield* verifyForcePushBoundary(boundary, semanticHead);
                     return yield* git.novel(onto, branch, yield* git.commits(boundary, branch));
                   } else {
                     const fetchedHead = yield* git.fetchRef(recovered.value.fetchRef);
@@ -972,6 +977,39 @@ ${note}`;
                 if (semantic.matchedParentPrefix <= matchedParentPrefix) continue;
                 selected = semantic.commits;
                 matchedParentPrefix = semantic.matchedParentPrefix;
+              }
+
+              if (
+                savedParent &&
+                trunk(parent) &&
+                link.pr &&
+                all.length > 1 &&
+                matchedParentPrefix === 0 &&
+                !savedParentBoundaryVerified
+              ) {
+                const recovered = yield* codeHost.replayBase(Number(link.pr), parent);
+                if (Option.isSome(recovered) && recovered.value.kind === "force-push-boundary") {
+                  const { boundary, semanticHead } = recovered.value;
+                  yield* verifyForcePushBoundary(boundary, semanticHead);
+                  const [firstParent, secondParent, thirdParent, embeddedAnchor, sharedAnchor] =
+                    yield* Effect.all([
+                      git.head(`${branch}^1`),
+                      git.head(`${branch}^2`),
+                      git.head(`${branch}^3`),
+                      git.base(savedParent, anchor),
+                      git.base(branch, savedParent),
+                    ]);
+                  savedParentBoundaryVerified =
+                    Option.isSome(firstParent) &&
+                    firstParent.value === semanticHead &&
+                    Option.isSome(secondParent) &&
+                    secondParent.value === anchor &&
+                    Option.isNone(thirdParent) &&
+                    Option.isSome(embeddedAnchor) &&
+                    embeddedAnchor.value === anchor &&
+                    Option.isSome(sharedAnchor) &&
+                    sharedAnchor.value === anchor;
+                }
               }
 
               if (

--- a/src/services/code-host/GitHub.ts
+++ b/src/services/code-host/GitHub.ts
@@ -1,10 +1,12 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import {
   ExecError,
   CodeHostChangeNotFoundError,
   CodeHostDecodeError,
+  CodeHostReplayBaseNotFoundError,
   PullLabel,
   pullMeta,
   PullMeta,
@@ -36,6 +38,41 @@ class PullWatch extends Schema.Class<PullWatch>("PullWatch")({
   state: Schema.String,
   mergedAt: Schema.NullOr(Schema.String),
 }) {}
+
+class RepositoryView extends Schema.Class<RepositoryView>("RepositoryView")({
+  nameWithOwner: Schema.String,
+}) {}
+
+class BaseRefChangedEvent extends Schema.Class<BaseRefChangedEvent>("BaseRefChangedEvent")({
+  createdAt: Schema.String,
+  previousRefName: Schema.String,
+  currentRefName: Schema.String,
+}) {}
+
+class BaseRefHistory extends Schema.Class<BaseRefHistory>("BaseRefHistory")({
+  data: Schema.Struct({
+    repository: Schema.NullOr(
+      Schema.Struct({
+        pullRequest: Schema.NullOr(
+          Schema.Struct({
+            timelineItems: Schema.Struct({
+              nodes: Schema.Array(Schema.NullOr(BaseRefChangedEvent)),
+            }),
+          }),
+        ),
+      }),
+    ),
+  }),
+}) {}
+
+class MergedPull extends Schema.Class<MergedPull>("MergedPull")({
+  number: Schema.Number,
+  headRefName: Schema.String,
+  headRefOid: Schema.String,
+  mergedAt: Schema.NullOr(Schema.String),
+}) {}
+
+const MergedPulls = Schema.Array(MergedPull);
 
 class PullListData extends Schema.Class<PullListData>("PullListData")({
   number: Schema.Number,
@@ -76,6 +113,24 @@ const decodePullView = (args: ReadonlyArray<string>, out: string) =>
 const decodePullWatch = (args: ReadonlyArray<string>, out: string) =>
   Effect.try({
     try: () => Schema.decodeUnknownSync(PullWatch)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodeRepositoryView = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(RepositoryView)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodeBaseRefHistory = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(BaseRefHistory)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodeMergedPulls = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(MergedPulls)(JSON.parse(extractJson(out))),
     catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
   });
 
@@ -158,6 +213,85 @@ export const layer = Layer.effect(
         Effect.flatMap((out) => decodePullView(args, out)),
         Effect.map(meta),
       );
+    });
+
+    const replayBase = Effect.fn("CodeHost.github.replayBase")(function* (
+      pr: number,
+      currentBase: string,
+    ) {
+      const repositoryArgs = ["repo", "view", "--json", "nameWithOwner"];
+      const repository = yield* run(repositoryArgs).pipe(
+        Effect.flatMap((out) => decodeRepositoryView(repositoryArgs, out)),
+      );
+      const [owner, name] = repository.nameWithOwner.split("/", 2);
+      if (!owner || !name) {
+        return yield* Effect.fail(
+          new CodeHostDecodeError(
+            "gh",
+            repositoryArgs,
+            repository.nameWithOwner,
+            "expected owner/name",
+          ),
+        );
+      }
+
+      const query =
+        "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){timelineItems(first:100,itemTypes:[BASE_REF_CHANGED_EVENT]){nodes{... on BaseRefChangedEvent{createdAt previousRefName currentRefName}}}}}}";
+      const historyArgs = [
+        "api",
+        "graphql",
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `name=${name}`,
+        "-F",
+        `number=${pr}`,
+        "-f",
+        `query=${query}`,
+      ];
+      const history = yield* run(historyArgs).pipe(
+        Effect.flatMap((out) => decodeBaseRefHistory(historyArgs, out)),
+      );
+      const event = history.data.repository?.pullRequest?.timelineItems.nodes
+        .filter((item): item is BaseRefChangedEvent => item?.currentRefName === currentBase)
+        .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+        .at(-1);
+      if (!event) return Option.none<CodeHost.ReplayBase>();
+
+      const mergedArgs = [
+        "pr",
+        "list",
+        "--state",
+        "merged",
+        "--head",
+        event.previousRefName,
+        "--json",
+        "number,headRefName,headRefOid,mergedAt",
+        "--limit",
+        "100",
+      ];
+      const merged = yield* run(mergedArgs).pipe(
+        Effect.flatMap((out) => decodeMergedPulls(mergedArgs, out)),
+      );
+      const eventTime = Date.parse(event.createdAt);
+      const parent = merged
+        .filter((item) => item.headRefName === event.previousRefName)
+        .sort((left, right) => {
+          const leftDistance = Math.abs(Date.parse(left.mergedAt ?? "") - eventTime);
+          const rightDistance = Math.abs(Date.parse(right.mergedAt ?? "") - eventTime);
+          return leftDistance - rightDistance || right.number - left.number;
+        })[0];
+      if (!parent) {
+        return yield* Effect.fail(new CodeHostReplayBaseNotFoundError(pr, event.previousRefName));
+      }
+
+      return Option.some({
+        branch: event.previousRefName,
+        currentBase,
+        head: parent.headRefOid,
+        fetchRef: `refs/pull/${parent.number}/head`,
+        change: parent.number,
+      });
     });
 
     const auto = Effect.fn("CodeHost.github.auto")((pr: number) =>
@@ -247,6 +381,7 @@ export const layer = Layer.effect(
       wait,
       changes,
       change,
+      replayBase,
       edit,
       body,
       close,

--- a/src/services/code-host/GitHub.ts
+++ b/src/services/code-host/GitHub.ts
@@ -358,11 +358,33 @@ export const layer = Layer.effect(
         return yield* Effect.fail(new CodeHostReplayBaseNotFoundError(pr, event.previousRefName));
       }
 
+      const parentForcePushArgs = [
+        "api",
+        "graphql",
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `name=${name}`,
+        "-F",
+        `number=${parent.number}`,
+        "-f",
+        `query=${forcePushQuery}`,
+      ];
+      const parentForcePushHistory = yield* run(parentForcePushArgs).pipe(
+        Effect.flatMap((out) => decodeForcePushHistory(parentForcePushArgs, out)),
+      );
+      const historicalHeads =
+        parentForcePushHistory.data.repository?.pullRequest?.timelineItems.nodes
+          .filter((item): item is HeadRefForcePushedEvent => item !== null)
+          .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+          .flatMap((item) => (item.beforeCommit ? [item.beforeCommit.oid] : [])) ?? [];
+
       return Option.some({
         kind: "merged-parent" as const,
         branch: event.previousRefName,
         currentBase,
         head: parent.headRefOid,
+        historicalHeads,
         fetchRef: `refs/pull/${parent.number}/head`,
         change: parent.number,
       });

--- a/src/services/code-host/GitHub.ts
+++ b/src/services/code-host/GitHub.ts
@@ -65,6 +65,37 @@ class BaseRefHistory extends Schema.Class<BaseRefHistory>("BaseRefHistory")({
   }),
 }) {}
 
+class ForcePushCommit extends Schema.Class<ForcePushCommit>("ForcePushCommit")({
+  oid: Schema.String,
+  parents: Schema.Struct({
+    nodes: Schema.Array(Schema.Struct({ oid: Schema.String })),
+  }),
+}) {}
+
+class HeadRefForcePushedEvent extends Schema.Class<HeadRefForcePushedEvent>(
+  "HeadRefForcePushedEvent",
+)({
+  createdAt: Schema.String,
+  beforeCommit: Schema.NullOr(ForcePushCommit),
+  afterCommit: Schema.NullOr(ForcePushCommit),
+}) {}
+
+class ForcePushHistory extends Schema.Class<ForcePushHistory>("ForcePushHistory")({
+  data: Schema.Struct({
+    repository: Schema.NullOr(
+      Schema.Struct({
+        pullRequest: Schema.NullOr(
+          Schema.Struct({
+            timelineItems: Schema.Struct({
+              nodes: Schema.Array(Schema.NullOr(HeadRefForcePushedEvent)),
+            }),
+          }),
+        ),
+      }),
+    ),
+  }),
+}) {}
+
 class MergedPull extends Schema.Class<MergedPull>("MergedPull")({
   number: Schema.Number,
   headRefName: Schema.String,
@@ -125,6 +156,12 @@ const decodeRepositoryView = (args: ReadonlyArray<string>, out: string) =>
 const decodeBaseRefHistory = (args: ReadonlyArray<string>, out: string) =>
   Effect.try({
     try: () => Schema.decodeUnknownSync(BaseRefHistory)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodeForcePushHistory = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(ForcePushHistory)(JSON.parse(extractJson(out))),
     catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
   });
 
@@ -235,6 +272,42 @@ export const layer = Layer.effect(
         );
       }
 
+      const forcePushQuery =
+        "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){timelineItems(last:100,itemTypes:[HEAD_REF_FORCE_PUSHED_EVENT]){nodes{... on HeadRefForcePushedEvent{createdAt beforeCommit{oid parents(first:2){nodes{oid}}} afterCommit{oid parents(first:2){nodes{oid}}}}}}}}}";
+      const forcePushArgs = [
+        "api",
+        "graphql",
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `name=${name}`,
+        "-F",
+        `number=${pr}`,
+        "-f",
+        `query=${forcePushQuery}`,
+      ];
+      const forcePushHistory = yield* run(forcePushArgs).pipe(
+        Effect.flatMap((out) => decodeForcePushHistory(forcePushArgs, out)),
+      );
+      const forcePushes = forcePushHistory.data.repository?.pullRequest?.timelineItems.nodes
+        .filter((item): item is HeadRefForcePushedEvent => item !== null)
+        .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+      const latestForcePush = forcePushes?.at(-1);
+      if (latestForcePush) {
+        const before = latestForcePush.beforeCommit;
+        const after = latestForcePush.afterCommit;
+        if (!before || !after || after.parents.nodes.length !== 1) {
+          return yield* Effect.fail(new CodeHostReplayBaseNotFoundError(pr, "force-push history"));
+        }
+        return Option.some({
+          kind: "force-push-boundary" as const,
+          currentBase,
+          before: before.oid,
+          semanticHead: after.oid,
+          boundary: after.parents.nodes[0]!.oid,
+        });
+      }
+
       const query =
         "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){timelineItems(first:100,itemTypes:[BASE_REF_CHANGED_EVENT]){nodes{... on BaseRefChangedEvent{createdAt previousRefName currentRefName}}}}}}";
       const historyArgs = [
@@ -286,6 +359,7 @@ export const layer = Layer.effect(
       }
 
       return Option.some({
+        kind: "merged-parent" as const,
         branch: event.previousRefName,
         currentBase,
         head: parent.headRefOid,

--- a/src/services/code-host/GitHub.ts
+++ b/src/services/code-host/GitHub.ts
@@ -12,6 +12,7 @@ import {
   PullMeta,
   pullRef,
   PullRef,
+  UnsupportedCodeHostOperation,
 } from "../../domain/model.ts";
 import * as Proc from "../../platform/proc.ts";
 import { StackConfig } from "../Config.ts";
@@ -37,6 +38,40 @@ class PullView extends Schema.Class<PullView>("PullView")({
 class PullWatch extends Schema.Class<PullWatch>("PullWatch")({
   state: Schema.String,
   mergedAt: Schema.NullOr(Schema.String),
+}) {}
+
+class PullMergeView extends Schema.Class<PullMergeView>("PullMergeView")({
+  head: Schema.Struct({ sha: Schema.String }),
+  stack: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        number: Schema.Number,
+      }),
+    ),
+  ),
+}) {}
+
+class NativeStackView extends Schema.Class<NativeStackView>("NativeStackView")({
+  pull_requests: Schema.Array(
+    Schema.Struct({
+      number: Schema.Number,
+      state: Schema.String,
+      merged_at: Schema.NullOr(Schema.String),
+    }),
+  ),
+}) {}
+
+class AsyncMergeView extends Schema.Class<AsyncMergeView>("AsyncMergeView")({
+  status: Schema.String,
+  details: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        uuid: Schema.optional(Schema.String),
+        message: Schema.optional(Schema.String),
+        sha: Schema.optional(Schema.String),
+      }),
+    ),
+  ),
 }) {}
 
 class RepositoryView extends Schema.Class<RepositoryView>("RepositoryView")({
@@ -144,6 +179,24 @@ const decodePullView = (args: ReadonlyArray<string>, out: string) =>
 const decodePullWatch = (args: ReadonlyArray<string>, out: string) =>
   Effect.try({
     try: () => Schema.decodeUnknownSync(PullWatch)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodePullMergeView = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(PullMergeView)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodeNativeStackView = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(NativeStackView)(JSON.parse(extractJson(out))),
+    catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
+  });
+
+const decodeAsyncMergeView = (args: ReadonlyArray<string>, out: string) =>
+  Effect.try({
+    try: () => Schema.decodeUnknownSync(AsyncMergeView)(JSON.parse(extractJson(out))),
     catch: (err) => new CodeHostDecodeError("gh", args, out, String(err)),
   });
 
@@ -390,16 +443,106 @@ export const layer = Layer.effect(
       });
     });
 
-    const auto = Effect.fn("CodeHost.github.auto")((pr: number) =>
-      run(["pr", "merge", `${pr}`, "--auto", "--squash"]).pipe(Effect.asVoid),
-    );
+    const nativeStackMerge = Effect.fn("CodeHost.github.nativeStackMerge")(function* (
+      pr: number,
+      mergeAction: "default" | "direct_merge",
+      admin: boolean,
+    ) {
+      const pullArgs = ["api", `repos/{owner}/{repo}/pulls/${pr}`];
+      const pull = yield* run(pullArgs).pipe(
+        Effect.flatMap((out) => decodePullMergeView(pullArgs, out)),
+      );
+      if (!pull.stack) return false;
+      if (admin) {
+        return yield* Effect.fail(
+          new UnsupportedCodeHostOperation("github", "native stacked PR admin merge"),
+        );
+      }
 
-    const merge = Effect.fn("CodeHost.github.merge")(
-      (pr: number, opts?: { readonly admin?: boolean }) =>
-        run(["pr", "merge", `${pr}`, "--squash", ...(opts?.admin ? ["--admin"] : [])]).pipe(
-          Effect.asVoid,
+      const stackArgs = ["api", `repos/{owner}/{repo}/stacks/${pull.stack.number}`];
+      const stack = yield* run(stackArgs).pipe(
+        Effect.flatMap((out) => decodeNativeStackView(stackArgs, out)),
+      );
+      const targetIndex = stack.pull_requests.findIndex((item) => item.number === pr);
+      if (targetIndex === -1) {
+        return yield* Effect.fail(
+          new ExecError("gh", stackArgs, 1, `PR #${pr} is missing from native stack`),
+        );
+      }
+      const openLowerPull = stack.pull_requests
+        .slice(0, targetIndex)
+        .find((item) => item.state.toLowerCase() === "open" && item.merged_at === null);
+      if (openLowerPull) {
+        return yield* Effect.fail(
+          new ExecError(
+            "gh",
+            stackArgs,
+            1,
+            `Native stack merge of PR #${pr} would also merge open PR #${openLowerPull.number}`,
+          ),
+        );
+      }
+
+      const submitArgs = [
+        "api",
+        "--method",
+        "PUT",
+        `repos/{owner}/{repo}/pulls/${pr}/merge-async`,
+        "-f",
+        "merge_method=squash",
+        "-f",
+        `merge_action=${mergeAction}`,
+        "-f",
+        `sha=${pull.head.sha}`,
+      ];
+      const submittedOut = yield* run(submitArgs, [0, 1]);
+      let result = yield* decodeAsyncMergeView(submitArgs, submittedOut);
+
+      while (result.status === "pending") {
+        const requestId = result.details?.uuid;
+        if (!requestId) {
+          return yield* Effect.fail(
+            new CodeHostDecodeError(
+              "gh",
+              submitArgs,
+              submittedOut,
+              "pending asynchronous merge response is missing details.uuid",
+            ),
+          );
+        }
+        const pollArgs = ["api", `repos/{owner}/{repo}/pulls/${pr}/merge-async/${requestId}`];
+        const pollOut = yield* run(pollArgs);
+        result = yield* decodeAsyncMergeView(pollArgs, pollOut);
+        if (result.status === "pending") {
+          yield* Effect.sleep(cfg.codeHostWaitIntervalMillis);
+        }
+      }
+
+      if (result.status === "merged") return true;
+      if (mergeAction === "default" && result.status === "enqueued") return true;
+      return yield* Effect.fail(
+        new ExecError(
+          "gh",
+          submitArgs,
+          1,
+          result.details?.message ?? `asynchronous merge ended with status ${result.status}`,
         ),
-    );
+      );
+    });
+
+    const auto = Effect.fn("CodeHost.github.auto")(function* (pr: number) {
+      if (yield* nativeStackMerge(pr, "default", false)) return;
+      yield* run(["pr", "merge", `${pr}`, "--auto", "--squash"]);
+    });
+
+    const merge = Effect.fn("CodeHost.github.merge")(function* (
+      pr: number,
+      opts?: { readonly admin?: boolean },
+    ) {
+      const admin = opts?.admin ?? false;
+      if (yield* nativeStackMerge(pr, "direct_merge", admin)) return;
+      yield* run(["pr", "merge", `${pr}`, "--squash", ...(admin ? ["--admin"] : [])]);
+    });
 
     const wait = Effect.fn("CodeHost.github.wait")((pr: number) =>
       Effect.gen(function* () {

--- a/src/services/code-host/GitLab.ts
+++ b/src/services/code-host/GitLab.ts
@@ -1,6 +1,7 @@
 import * as Cache from "effect/Cache";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import {
   ExecError,
@@ -179,6 +180,10 @@ export const layer = Layer.effect(
       );
     });
 
+    const replayBase = Effect.fn("CodeHost.gitlab.replayBase")(() =>
+      Effect.succeed(Option.none<CodeHost.ReplayBase>()),
+    );
+
     const auto = Effect.fn("CodeHost.gitlab.auto")((pr: number) =>
       run([
         "api",
@@ -286,6 +291,7 @@ export const layer = Layer.effect(
       wait,
       changes,
       change,
+      replayBase,
       edit,
       body,
       close,

--- a/src/services/code-host/Memory.ts
+++ b/src/services/code-host/Memory.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import {
   CodeHostChangeNotFoundError,
@@ -19,6 +20,7 @@ export interface Options {
   readonly pulls?: ReadonlyArray<PullRef>;
   readonly metas?: ReadonlyArray<PullMeta>;
   readonly log?: Array<string>;
+  readonly replayBases?: ReadonlyMap<number, CodeHost.ReplayBase>;
 }
 
 export const layer = (opts: Options) =>
@@ -64,6 +66,15 @@ export const layer = (opts: Options) =>
         const made = metaFor(found);
         yield* Ref.update(metasRef, (metas) => new Map(metas).set(pr, made));
         return made;
+      });
+      const replayBase = Effect.fn("CodeHost.memory.replayBase")((
+        pr: number,
+        currentBase: string,
+      ) => {
+        const value = opts.replayBases?.get(pr);
+        return Effect.succeed(
+          value?.currentBase === currentBase ? Option.some(value) : Option.none(),
+        );
       });
       const edit = Effect.fn("CodeHost.memory.edit")((pr: number, base: string) =>
         Effect.gen(function* () {
@@ -211,6 +222,7 @@ export const layer = (opts: Options) =>
         wait,
         changes,
         change,
+        replayBase,
         edit,
         body,
         close,

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -3390,6 +3390,84 @@ describe("Stack", () => {
     }).pipe(Effect.provide(test.layer));
   });
 
+  it.effect("sync fails closed for the 25-layer no-event root topology", () => {
+    const branches = [
+      "francisco/rest-compliance-10a1a-unused-inbox-reads",
+      ...Array.from({ length: 24 }, (_, index) => `francisco/rest-compliance-layer-${index + 2}`),
+    ];
+    const branchHeads = new Map(
+      branches.map((branch, index) => [branch, index === 0 ? "a8334210" : `head-${index + 1}`]),
+    );
+    const rootAnchor = "e0e3e3aa";
+    const refs = [
+      ref("dev", "319b394c"),
+      ...branches.map((branch) => ref(branch, branchHeads.get(branch)!)),
+    ];
+    const pulls = branches.map((branch, index) =>
+      pr(
+        3347 + index,
+        branch,
+        index === 0 ? "francisco/rest-compliance-09b8" : branches[index - 1]!,
+      ),
+    );
+    const links = branches.map((branch, index) =>
+      stackLink({
+        branch,
+        parent: index === 0 ? "dev" : branches[index - 1]!,
+        anchor: index === 0 ? rootAnchor : branchHeads.get(branches[index - 1]!)!,
+        pr: 3347 + index,
+      }),
+    );
+    const baseEntries: Array<readonly [string, string, string]> = [
+      [branches[0]!, "dev", rootAnchor],
+      ...branches
+        .slice(1)
+        .map(
+          (branch, index) =>
+            [branch, branches[index]!, branchHeads.get(branches[index]!)!] as const,
+        ),
+    ];
+    const inherited = Array.from({ length: 104 }, (_, index) => `inherited-${index + 1}`);
+    const commitRequests: Array<string> = [];
+    const mutations: Array<string> = [];
+    const layer = stackTestLayer({
+      current: branches.at(-1)!,
+      refs,
+      pulls,
+      bases: bases(...baseEntries),
+      state: stackState(links),
+      service: {
+        commits: (from, branch) =>
+          Effect.sync(() => {
+            commitRequests.push(`${from}..${branch}`);
+            return branch === branches[0] ? [...inherited, "9d375049", "a8334210"] : [];
+          }),
+        novel: (_parent, branch, commits) =>
+          Effect.sync(() => {
+            mutations.push(`novel ${branch}`);
+            return commits;
+          }),
+        replay: (branch) => Effect.sync(() => void mutations.push(`replay ${branch}`)),
+        backup: (branch) => Effect.sync(() => void mutations.push(`backup ${branch}`)),
+        push: (branch) => Effect.sync(() => void mutations.push(`push ${branch}`)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const store = yield* Store;
+      const error = yield* Effect.flip(stack.sync({ branch: branches[0]! }));
+
+      expect(String(error)).toContain("semantic replay boundary required");
+      expect(String(error)).toContain("refusing to replay 106 commits");
+      expect(String(error)).toContain(rootAnchor);
+      expect(commitRequests).toContain(`${rootAnchor}..${branches[0]}`);
+      expect(mutations).toEqual([]);
+      expect((yield* store.read()).links).toHaveLength(25);
+      expect(yield* store.readUndo()).toBeNull();
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync filters already-upstream parent commits before replay", () => {
     const test = makeSyncNovel();
 

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -3765,9 +3765,13 @@ describe("Stack", () => {
         yield* shell(author, "git", ["push", "-u", "origin", "main"]);
         yield* shell(root, "git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
 
+        yield* shell(author, "git", ["checkout", "-b", "stale-anchor"]);
+        yield* shell(author, "git", ["commit", "--allow-empty", "-m", "stale stack anchor"]);
+        const staleAnchor = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["checkout", "main"]);
+
         yield* shell(author, "git", ["checkout", "-b", "persisted-anchor"]);
         yield* shell(author, "git", ["commit", "--allow-empty", "-m", "persisted stack anchor"]);
-        const anchor = yield* shell(author, "git", ["rev-parse", "HEAD"]);
         yield* shell(author, "git", ["checkout", "main"]);
 
         yield* shell(author, "git", ["checkout", "-b", "root", baseHead]);
@@ -3911,7 +3915,7 @@ describe("Stack", () => {
               new StackState({
                 version: 1,
                 links: [
-                  stackLink({ branch: "root", parent: "main", anchor, pr: 3265 }),
+                  stackLink({ branch: "root", parent: "main", anchor: staleAnchor, pr: 3265 }),
                   stackLink({ branch: "child", parent: "root", anchor: childAnchor, pr: 3267 }),
                 ],
               }),

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1625,9 +1625,24 @@ describe("GitHub", () => {
             if (args[0] === "repo") return JSON.stringify({ nameWithOwner: "alaro-ai/alaro" });
             if (args[0] === "api") {
               if (args.some((arg) => arg.includes("HEAD_REF_FORCE_PUSHED_EVENT"))) {
+                const parentHistory = args.includes("number=100")
+                  ? [
+                      {
+                        createdAt: "2026-08-11T12:16:57Z",
+                        beforeCommit: {
+                          oid: "e70e19d723bd0d1435909397523fdc9f4ce3ae61",
+                          parents: { nodes: [{ oid: "dbe58fd5" }] },
+                        },
+                        afterCommit: {
+                          oid: "092cf7f0a979f4b1409de5723b735557476e25a2",
+                          parents: { nodes: [{ oid: "908bca65" }] },
+                        },
+                      },
+                    ]
+                  : [];
                 return JSON.stringify({
                   data: {
-                    repository: { pullRequest: { timelineItems: { nodes: [] } } },
+                    repository: { pullRequest: { timelineItems: { nodes: parentHistory } } },
                   },
                 });
               }
@@ -1670,10 +1685,11 @@ describe("GitHub", () => {
         branch: "landed-parent",
         currentBase: "main",
         head: "exact-parent-head",
+        historicalHeads: ["e70e19d723bd0d1435909397523fdc9f4ce3ae61"],
         fetchRef: "refs/pull/100/head",
         change: 100,
       });
-      expect(calls).toHaveLength(4);
+      expect(calls).toHaveLength(5);
       expect(calls[0]).toEqual(["gh", "repo", "view", "--json", "nameWithOwner"]);
       expect(calls[1]).toContain("number=101");
       expect(calls[1]).toContainEqual(expect.stringContaining("HEAD_REF_FORCE_PUSHED_EVENT"));
@@ -1691,6 +1707,8 @@ describe("GitHub", () => {
         "--limit",
         "100",
       ]);
+      expect(calls[4]).toContain("number=100");
+      expect(calls[4]).toContainEqual(expect.stringContaining("HEAD_REF_FORCE_PUSHED_EVENT"));
     }).pipe(
       Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
     );
@@ -3484,46 +3502,80 @@ describe("Stack", () => {
     }).pipe(Effect.provide(test.layer));
   });
 
-  it.effect("sync prefers a persisted anchor shared by the root and trunk", () => {
-    const commitRequests: Array<string> = [];
-    const replayBaseRequests: Array<number> = [];
+  it.effect("sync recovers the exact promoted #3410 suffix from its parent's old head", () => {
+    const anchor = "e0e3e3aa04823085af12ca54188df0473b13eef9";
+    const forbidden = "856ea56814d5a8425044525370cef7fcba62b9ba";
+    const oldParent = "e70e19d723bd0d1435909397523fdc9f4ce3ae61";
+    const repairedParent = "092cf7f0a979f4b1409de5723b735557476e25a2";
+    const root = "e3999ebfab5709ae903a7166a1b95085e1be6baf";
+    const child = "3f75a349091bcf1db9bee5f0f8f87da21ef8a477";
+    const selected: Array<ReadonlyArray<string>> = [];
     const layer = stackTestLayer({
       current: "root",
-      refs: [ref("dev", "dev-new"), ref("root", "root-head")],
-      pulls: [pr(1, "root", "dev")],
-      state: stackState([stackLink({ branch: "root", parent: "dev", anchor: "dev-old", pr: 1 })]),
+      refs: [
+        ref("dev", "11fd7a7486099790131eb614a1ff731258e1cbd7"),
+        ref("root", root),
+        ref("child", child),
+      ],
+      pulls: [pr(3410, "root", "dev"), pr(3411, "child", "root")],
+      state: stackState([
+        stackLink({ branch: "root", parent: "dev", anchor, pr: 3410 }),
+        stackLink({ branch: "child", parent: "root", anchor: root, pr: 3411 }),
+      ]),
       service: {
         head: (name) => {
           const heads: Readonly<Record<string, string>> = {
-            dev: "dev-new",
-            "origin/dev": "dev-new",
-            root: "root-head",
-            "dev-old": "dev-old",
+            dev: "11fd7a7486099790131eb614a1ff731258e1cbd7",
+            "origin/dev": "11fd7a7486099790131eb614a1ff731258e1cbd7",
+            root,
+            child,
+            [anchor]: anchor,
+            [oldParent]: oldParent,
+            [repairedParent]: repairedParent,
           };
           return Effect.succeed(Option.fromNullishOr(heads[name]));
         },
         base: (branch, parent) => {
-          const sharedBase =
-            (branch === "root" && (parent === "origin/dev" || parent === "dev-old")) ||
-            (branch === "origin/dev" && parent === "dev-old");
-          return Effect.succeed(sharedBase ? Option.some("dev-old") : Option.none());
+          const value: Readonly<Record<string, string>> = {
+            [`root:origin/dev`]: anchor,
+            [`root:${anchor}`]: anchor,
+            [`origin/dev:${anchor}`]: anchor,
+            [`${repairedParent}:${anchor}`]: anchor,
+            [`root:${repairedParent}`]: anchor,
+            [`${oldParent}:${anchor}`]: anchor,
+            [`root:${oldParent}`]: oldParent,
+            "child:root": root,
+          };
+          return Effect.succeed(Option.fromNullishOr(value[`${branch}:${parent}`]));
         },
         commits: (from, branch) =>
+          Effect.succeed(
+            from === oldParent && branch === "root"
+              ? [root]
+              : from === anchor && branch === "root"
+                ? [forbidden, oldParent, root]
+                : [],
+          ),
+        semanticCommits: () =>
+          Effect.succeed({ commits: [forbidden, oldParent, root], matchedParentPrefix: 0 }),
+        novel: (_parent, branch, commits) =>
           Effect.sync(() => {
-            commitRequests.push(`${from}..${branch}`);
-            return ["root-1", "root-2"];
+            if (branch === "root") selected.push(commits);
+            return commits;
           }),
-        replayBase: (change) =>
-          Effect.sync(() => {
-            replayBaseRequests.push(change);
-            return Option.some<CodeHost.ReplayBase>({
-              kind: "force-push-boundary",
+        fetchRef: () => Effect.succeed(repairedParent),
+        replayBase: () =>
+          Effect.succeed(
+            Option.some<CodeHost.ReplayBase>({
+              kind: "merged-parent",
+              branch: "francisco/rest-compliance-10c5-canonical-reply-integrations",
               currentBase: "dev",
-              before: "old-root",
-              semanticHead: "root-1",
-              boundary: "inherited-boundary",
-            });
-          }),
+              head: repairedParent,
+              historicalHeads: [oldParent],
+              fetchRef: "refs/pull/3409/head",
+              change: 3409,
+            }),
+          ),
       },
     });
 
@@ -3531,9 +3583,10 @@ describe("Stack", () => {
       const stack = yield* Stack;
       const preview = yield* stack.sync({ branch: "root" });
 
-      expect(preview.join("\n")).toContain("root #1 would rebase onto dev");
-      expect(commitRequests).toEqual(["dev-old..root"]);
-      expect(replayBaseRequests).toEqual([1]);
+      expect(preview.join("\n")).toContain("root #3410 would rebase onto dev");
+      expect(preview.join("\n")).toContain("child #3411 would rebase onto root");
+      expect(selected).toContainEqual([root]);
+      expect(selected.flat()).not.toContain(forbidden);
     }).pipe(Effect.provide(layer));
   });
 
@@ -3742,6 +3795,7 @@ describe("Stack", () => {
                     branch: "landed-parent",
                     currentBase: "main",
                     head: landedParentHead,
+                    historicalHeads: [],
                     fetchRef: "refs/pull/100/head",
                     change: 100,
                   },

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1142,7 +1142,7 @@ const makeSyncNovel = () => {
             Effect.succeed(
               from === "dev-1" && branch === "stack-b"
                 ? ["b1", "b2"]
-                : from === "old-base" && branch === "stack-c"
+                : from === "stack-b-1" && branch === "stack-c"
                   ? ["b1", "b2", "c1"]
                   : [],
             ),
@@ -2354,6 +2354,49 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("sync infers a child anchor from the unchanged remote parent tip", () => {
+    const commitRanges: Array<string> = [];
+    const refs = [
+      ref("dev", "dev-head"),
+      ref("parent", "parent-repaired"),
+      ref("child", "child-old"),
+    ];
+    const layer = stackTestLayer({
+      current: "child",
+      refs,
+      pulls: [pr(1, "parent", "dev"), pr(2, "child", "parent")],
+      bases: bases(
+        ["parent", "dev", "dev-head"],
+        ["child", "parent", "shared-merge-base"],
+        ["child", "origin/parent", "parent-before-repair"],
+      ),
+      service: {
+        head: (name) =>
+          Effect.succeed(
+            Option.fromNullishOr(
+              name === "origin/parent" ? "parent-before-repair" : refsHead(refs, name),
+            ),
+          ),
+        commits: (from, branch) =>
+          Effect.sync(() => {
+            commitRanges.push(`${from}:${branch}`);
+            return ["child-only"];
+          }),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const store = yield* Store;
+      yield* stack.sync({ apply: true });
+      const undo = yield* store.readUndo();
+
+      expect(commitRanges).toContain("parent-before-repair:child");
+      expect(commitRanges).not.toContain("shared-merge-base:child");
+      expect(undo?.actions).toContain("infer link: child -> parent @ parent-before-repair");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync previews stale metadata reconciliation", () => {
     const layer = stackTestLayer({
       current: "stack-b",
@@ -3124,6 +3167,96 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("sync uses persisted anchors for a repaired parent fork across repeated syncs", () => {
+    const seen: Array<string> = [];
+    const refs = new Map([
+      ["dev", ref("dev", "dev-head")],
+      ["parent", ref("parent", "parent-repaired")],
+      ["child-a", ref("child-a", "child-a-old")],
+      ["child-b", ref("child-b", "child-b-old")],
+    ]);
+    const baseMap = new Map([
+      ["parent:origin/dev", "dev-head"],
+      ["child-a:parent", "shared-merge-base"],
+      ["child-b:parent", "shared-merge-base"],
+    ]);
+    const pulls = [pr(1, "parent", "dev"), pr(2, "child-a", "parent"), pr(3, "child-b", "parent")];
+    const layer = stackTestLayer({
+      current: "child-a",
+      refs: [...refs.values()],
+      pulls,
+      state: stackState([
+        stackLink({ branch: "parent", parent: "dev", anchor: "dev-head", pr: 1 }),
+        stackLink({ branch: "child-a", parent: "parent", anchor: "parent-before-repair", pr: 2 }),
+        stackLink({ branch: "child-b", parent: "parent", anchor: "parent-before-repair", pr: 3 }),
+      ]),
+      service: {
+        refs: () => Effect.succeed([...refs.values()]),
+        head: (name) =>
+          Effect.succeed(
+            Option.fromNullishOr(
+              refs.get(name)?.head ??
+                (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined),
+            ),
+          ),
+        base: (branch, parent) =>
+          Effect.succeed(Option.fromNullishOr(baseMap.get(`${branch}:${parent}`))),
+        commits: (from, branch) =>
+          Effect.succeed(
+            from === "parent-before-repair"
+              ? [`${branch}-only`]
+              : from === "shared-merge-base"
+                ? ["parent-1", `${branch}-only`]
+                : [],
+          ),
+        novel: (_parent, _branch, commits) => Effect.succeed(commits),
+        replay: (branch, parent, commits) =>
+          Effect.sync(() => {
+            seen.push(`${branch}:${commits.join(",")}`);
+            refs.set(branch, ref(branch, `${branch}-repaired`));
+            baseMap.set(`${branch}:${parent}`, refs.get(parent)?.head ?? "");
+          }),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.sync({ apply: true });
+      yield* stack.sync({ apply: true });
+
+      expect(seen).toEqual(["child-a:child-a-only", "child-b:child-b-only"]);
+      expect(seen.join(",")).not.toContain("parent-1");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("sync leaves a clean root alone when only the trunk advanced", () => {
+    const seen: Array<string> = [];
+    const layer = stackTestLayer({
+      current: "child",
+      refs: [ref("dev", "dev-new"), ref("root", "root-head"), ref("child", "child-head")],
+      pulls: [pr(1, "root", "dev"), pr(2, "child", "root")],
+      bases: bases(["root", "origin/dev", "dev-old"], ["child", "root", "root-old"]),
+      state: stackState([
+        stackLink({ branch: "root", parent: "dev", anchor: "dev-old", pr: 1 }),
+        stackLink({ branch: "child", parent: "root", anchor: "root-old", pr: 2 }),
+      ]),
+      service: {
+        commits: (from, branch) =>
+          Effect.succeed(from === "root-old" && branch === "child" ? ["child-only"] : []),
+        novel: (_parent, _branch, commits) => Effect.succeed(commits),
+        replay: (branch, parent, commits) =>
+          Effect.sync(() => seen.push(`${branch}:${parent}:${commits.join(",")}`)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.sync({ apply: true, branch: "child" });
+
+      expect(seen).toEqual(["child:root:child-only"]);
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("undo restores the last applied mutation", () => {
     const test = makeSync();
 
@@ -3509,6 +3642,50 @@ describe("Stack", () => {
           }).pipe(Effect.provide(doneTest.layer)),
         ),
       );
+  });
+
+  it.effect("land bounds descendant repair depth and preserves deeper links", () => {
+    const planTest = makeLand();
+    const doneTest = makeLand();
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const plan = yield* stack.land("stack-a", { repairDepth: 1 });
+
+      expect(plan).toContain("would rebase stack-b onto dev");
+      expect(plan).not.toContain("would rebase stack-c onto stack-b");
+    })
+      .pipe(Effect.provide(planTest.layer))
+      .pipe(
+        Effect.flatMap(() =>
+          Effect.gen(function* () {
+            const stack = yield* Stack;
+            const store = yield* Store;
+            const done = yield* stack.land("stack-a", { apply: true, repairDepth: 1 });
+            const state = yield* store.read();
+
+            expect(done.join("\n")).toContain("stack-b #5");
+            expect(done.join("\n")).not.toContain("stack-c #3");
+            expect(doneTest.seen).toContain("rebase stack-b origin/dev");
+            expect(doneTest.seen).not.toContain("rebase stack-c stack-b");
+            expect(state.links.find((item) => item.branch === "stack-b")?.parent).toBe("dev");
+            expect(state.links.find((item) => item.branch === "stack-c")?.parent).toBe("stack-b");
+          }).pipe(Effect.provide(doneTest.layer)),
+        ),
+      );
+  });
+
+  it.effect("land rejects a non-positive repair depth", () => {
+    const test = makeLand();
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const error = yield* Effect.flip(stack.land("stack-a", { repairDepth: 0 }));
+
+      expect(error).toBeInstanceOf(StackOperationError);
+      expect(error.message).toContain("--repair-depth must be a positive integer");
+      expect(test.seen).toEqual([]);
+    }).pipe(Effect.provide(test.layer));
   });
 
   it.effect("land journals child retargets before a failed root merge", () => {

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -90,6 +90,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     head: () => Effect.succeed(Option.none()),
     base: () => Effect.succeed(Option.none()),
     commits: () => Effect.succeed([]),
+    mergeParents: () => Effect.succeed([]),
     semanticCommits: () => Effect.succeed({ commits: [], matchedParentPrefix: 0 }),
     novel: (_parent, _branch, commits) => Effect.succeed(commits),
     replay: () => Effect.void,
@@ -4882,6 +4883,168 @@ describe("Stack", () => {
         expect(log).not.toContain("body 3");
       }).pipe(Effect.provide(platform)),
     15_000,
+  );
+
+  it.effect(
+    "land trusts a child anchor embedded in the rewritten root history",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const origin = join(root, "origin.git");
+        const repo = join(root, "repo");
+        const log: Array<string> = [];
+
+        yield* shell(root, "git", ["init", "--bare", origin]);
+        yield* mkdirp(repo);
+        yield* shell(repo, "git", ["init", "-b", "dev"]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(repo, "git", ["remote", "add", "origin", origin]);
+
+        yield* commitFile(repo, "base.txt", "base\n", "base");
+        yield* shell(repo, "git", ["push", "-u", "origin", "dev"]);
+        const rootAnchor = yield* shell(repo, "git", ["rev-parse", "dev"]);
+
+        yield* shell(repo, "git", ["checkout", "-b", "root"]);
+        yield* commitFile(repo, "root.txt", "old root\n", "old root semantic layer");
+        const oldRoot = yield* shell(repo, "git", ["rev-parse", "root"]);
+
+        yield* shell(repo, "git", ["checkout", "-b", "child"]);
+        yield* commitFile(repo, "schema.ts", "schema\n", "own email thread schemas");
+        yield* commitFile(
+          repo,
+          "description.ts",
+          "legacy description\n",
+          "preserve legacy schema description",
+        );
+        const originalChild = yield* shell(repo, "git", ["rev-parse", "child"]);
+        yield* shell(repo, "git", ["push", "-u", "origin", "child"]);
+
+        yield* shell(repo, "git", ["checkout", "-b", "grandchild"]);
+        yield* commitFile(repo, "grandchild.ts", "grandchild\n", "deeper semantic layer");
+        const originalGrandchild = yield* shell(repo, "git", ["rev-parse", "grandchild"]);
+        yield* shell(repo, "git", ["push", "-u", "origin", "grandchild"]);
+
+        yield* shell(repo, "git", ["checkout", "dev"]);
+        yield* commitFile(repo, "trunk.txt", "advanced\n", "advance trunk");
+        yield* shell(repo, "git", ["push", "origin", "dev"]);
+        yield* shell(repo, "git", ["checkout", "-b", "repaired-root"]);
+        yield* commitFile(repo, "repaired.txt", "repaired\n", "repair root on current trunk");
+        yield* shell(repo, "git", ["merge", "--no-ff", "root", "-m", "preserve old root history"]);
+        const rewrittenRoot = yield* shell(repo, "git", ["rev-parse", "HEAD"]);
+        yield* shell(repo, "git", ["branch", "-f", "root", rewrittenRoot]);
+        yield* shell(repo, "git", ["push", "-u", "origin", "root", "--force"]);
+        yield* shell(repo, "git", ["checkout", "dev"]);
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["dev"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+        const layer = Stack.layer.pipe(
+          Layer.provideMerge(Progress.noop),
+          Layer.provideMerge(NodeServices.layer),
+          Layer.provideMerge(Proc.live),
+          Layer.provideMerge(cfgLayer),
+          Layer.provideMerge(Git.live.pipe(Layer.provide(cfgLayer))),
+          Layer.provideMerge(
+            integrationGitHub({
+              repo,
+              log,
+              pulls: [
+                pr(3411, "root", "dev"),
+                pr(3422, "child", "root"),
+                pr(3423, "grandchild", "child"),
+              ],
+              metas: [
+                pullMeta({
+                  number: 3411,
+                  title: "reply composer",
+                  body: "",
+                  head: "root",
+                  base: "dev",
+                  url: "u3411",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 3422,
+                  title: "own email thread schemas",
+                  body: "",
+                  head: "child",
+                  base: "root",
+                  url: "u3422",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 3423,
+                  title: "deeper layer",
+                  body: "",
+                  head: "grandchild",
+                  base: "child",
+                  url: "u3423",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+              ],
+            }),
+          ),
+          Layer.provideMerge(
+            Store.memory(
+              new StackState({
+                version: 1,
+                links: [
+                  stackLink({ branch: "root", parent: "dev", anchor: rootAnchor, pr: 3411 }),
+                  stackLink({ branch: "child", parent: "root", anchor: oldRoot, pr: 3422 }),
+                  stackLink({
+                    branch: "grandchild",
+                    parent: "child",
+                    anchor: originalChild,
+                    pr: 3423,
+                  }),
+                ],
+              }),
+            ),
+          ),
+        );
+
+        const result = yield* Effect.gen(function* () {
+          const stack = yield* Stack;
+          const preview = yield* stack.land("root", { repairDepth: 1 });
+          const applied = yield* stack.land("root", { apply: true, repairDepth: 1 });
+          return { preview, applied };
+        }).pipe(Effect.provide(layer));
+
+        const devHead = yield* shell(repo, "git", ["rev-parse", "dev"]);
+        const childHead = yield* shell(repo, "git", ["rev-parse", "child"]);
+        const subjects = yield* shell(repo, "git", [
+          "log",
+          "--reverse",
+          "--first-parent",
+          "--no-merges",
+          "--format=%s",
+          `${devHead}..${childHead}`,
+        ]);
+
+        expect(result.preview.join("\n")).toContain("would merge #3411 (root)");
+        expect(result.preview.join("\n")).toContain("would rebase child onto dev");
+        expect(result.preview.join("\n")).not.toContain("grandchild");
+        expect(result.applied.join("\n")).toContain("next root: child");
+        expect(result.applied.join("\n")).not.toContain("grandchild");
+        expect(subjects.split("\n")).toEqual([
+          "own email thread schemas",
+          "preserve legacy schema description",
+        ]);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/child"])).toBe(childHead);
+        expect(yield* shell(repo, "git", ["rev-parse", "grandchild"])).toBe(originalGrandchild);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/grandchild"])).toBe(
+          originalGrandchild,
+        );
+        expect(log).not.toContain("body 3423");
+      }).pipe(Effect.provide(platform)),
+    20_000,
   );
 
   it.effect("land supports a root-only repair depth", () => {

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1575,12 +1575,14 @@ describe("Git", () => {
     return Effect.gen(function* () {
       const git = yield* Git.Service;
       yield* git.push("stack-a");
-      yield* git.push("stack-b", "fork");
+      yield* git.push("stack-b", "fork", "expected-head");
+      yield* git.push("stack-c", "origin", null);
 
       expect(calls).toEqual([
         ["git", "push", "--force-with-lease", "-u", "origin", "stack-a"],
         ["git", "fetch", "fork", "--prune"],
-        ["git", "push", "--force-with-lease", "fork", "stack-b"],
+        ["git", "push", "--force-with-lease=refs/heads/stack-b:expected-head", "fork", "stack-b"],
+        ["git", "push", "--force-with-lease=refs/heads/stack-c:", "-u", "origin", "stack-c"],
       ]);
     }).pipe(Effect.provide(Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))));
   });

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -5047,6 +5047,198 @@ describe("Stack", () => {
     20_000,
   );
 
+  it.effect(
+    "land trusts a child anchor embedded in the child's preservation merge",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const origin = join(root, "origin.git");
+        const author = join(root, "author");
+        const repo = join(root, "fresh");
+        const log: Array<string> = [];
+
+        yield* shell(root, "git", ["init", "--bare", origin]);
+        yield* mkdirp(author);
+        yield* shell(author, "git", ["init", "-b", "main"]);
+        yield* shell(author, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(author, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(author, "git", ["remote", "add", "origin", origin]);
+
+        yield* commitFile(author, "base.txt", "base\n", "base");
+        const base = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "main"]);
+        yield* shell(root, "git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "root"]);
+        yield* commitFile(author, "root-anchor.txt", "anchor\n", "request drafting foundation");
+        const anchor = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* commitFile(author, "root.txt", "root\n", "defer request agents at capacity");
+        const originalRoot = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "root"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "child", base]);
+        const childSubjects = [
+          "verify mention-to-draft integration",
+          "verify raw mention gating",
+          "format mention seam tests",
+          "keep legacy root replay coverage",
+          "exercise production mention dispatch",
+          "keep integration capability-neutral",
+        ];
+        for (const [index, subject] of childSubjects.entries()) {
+          yield* commitFile(author, `child-${index}.txt`, `${subject}\n`, subject);
+        }
+        const semanticHead = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        const forcePushBoundary = yield* shell(author, "git", ["rev-parse", "HEAD^"]);
+        yield* shell(author, "git", [
+          "merge",
+          "--no-ff",
+          anchor,
+          "-m",
+          "preserve reviewed root history",
+        ]);
+        const originalChild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "child"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "grandchild"]);
+        yield* commitFile(author, "deeper.txt", "deeper\n", "deeper semantic layer");
+        const originalGrandchild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "grandchild"]);
+
+        yield* shell(root, "git", ["clone", "--no-local", origin, repo]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(repo, "git", [
+          "fetch",
+          "origin",
+          "root:root",
+          "child:child",
+          "grandchild:grandchild",
+        ]);
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["main"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+        const layer = Stack.layer.pipe(
+          Layer.provideMerge(Progress.noop),
+          Layer.provideMerge(NodeServices.layer),
+          Layer.provideMerge(Proc.live),
+          Layer.provideMerge(cfgLayer),
+          Layer.provideMerge(Git.live.pipe(Layer.provide(cfgLayer))),
+          Layer.provideMerge(
+            integrationGitHub({
+              repo,
+              log,
+              pulls: [
+                pr(3760, "root", "main"),
+                pr(3761, "child", "root"),
+                pr(3762, "grandchild", "child"),
+              ],
+              metas: [
+                pullMeta({
+                  number: 3760,
+                  title: "trigger drafting agents",
+                  body: "",
+                  head: "root",
+                  base: "main",
+                  url: "u3760",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 3761,
+                  title: "mention-to-draft",
+                  body: "",
+                  head: "child",
+                  base: "root",
+                  url: "u3761",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 3762,
+                  title: "deeper",
+                  body: "",
+                  head: "grandchild",
+                  base: "child",
+                  url: "u3762",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+              ],
+              replayBases: new Map([
+                [
+                  3761,
+                  {
+                    kind: "force-push-boundary",
+                    currentBase: "main",
+                    before: "previous-child-head",
+                    semanticHead,
+                    boundary: forcePushBoundary,
+                  },
+                ],
+              ]),
+            }),
+          ),
+          Layer.provideMerge(
+            Store.memory(
+              new StackState({
+                version: 1,
+                links: [
+                  stackLink({ branch: "root", parent: "main", anchor: base, pr: 3760 }),
+                  stackLink({ branch: "child", parent: "root", anchor, pr: 3761 }),
+                  stackLink({
+                    branch: "grandchild",
+                    parent: "child",
+                    anchor: originalChild,
+                    pr: 3762,
+                  }),
+                ],
+              }),
+            ),
+          ),
+        );
+
+        const result = yield* Effect.gen(function* () {
+          const stack = yield* Stack;
+          const preview = yield* stack.land("root", { repairDepth: 1 });
+          const applied = yield* stack.land("root", { apply: true, repairDepth: 1 });
+          return { preview, applied };
+        }).pipe(Effect.provide(layer));
+
+        const mainHead = yield* shell(repo, "git", ["rev-parse", "main"]);
+        const childHead = yield* shell(repo, "git", ["rev-parse", "child"]);
+        const repairedSubjects = yield* shell(repo, "git", [
+          "log",
+          "--reverse",
+          "--first-parent",
+          "--no-merges",
+          "--format=%s",
+          `${mainHead}..${childHead}`,
+        ]);
+
+        expect(result.preview.join("\n")).toContain("would merge #3760 (root)");
+        expect(result.preview.join("\n")).toContain("would rebase child onto main");
+        expect(result.preview.join("\n")).not.toContain("grandchild");
+        expect(result.applied.join("\n")).toContain("next root: child");
+        expect(result.applied.join("\n")).not.toContain("grandchild");
+        expect(repairedSubjects.split("\n")).toEqual(childSubjects);
+        expect(repairedSubjects).not.toContain("request drafting foundation");
+        expect(repairedSubjects).not.toContain("defer request agents at capacity");
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/child"])).toBe(childHead);
+        expect(yield* shell(repo, "git", ["rev-parse", "grandchild"])).toBe(originalGrandchild);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/grandchild"])).toBe(
+          originalGrandchild,
+        );
+        expect(originalRoot).not.toBe(mainHead);
+        expect(log).not.toContain("body 3762");
+      }).pipe(Effect.provide(platform)),
+    20_000,
+  );
+
   it.effect("land supports a root-only repair depth", () => {
     const planTest = makeLand();
     const doneTest = makeLand();

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -2220,6 +2220,60 @@ describe("Stack", () => {
     }).pipe(Effect.provide(make())),
   );
 
+  it.effect("adopt accepts an explicit ancestral replay anchor", () => {
+    const layer = stackTestLayer({
+      current: "child",
+      refs: [ref("dev", "dev-head"), ref("parent", "parent-new"), ref("child", "child-head")],
+      pulls: [pr(1, "parent", "dev"), pr(2, "child", "parent")],
+      bases: bases(["child", "parent", "shared-base"], ["child", "parent-old", "parent-old"]),
+      service: {
+        head: (name) =>
+          Effect.succeed(
+            Option.fromNullishOr(
+              name === "parent-old"
+                ? "parent-old"
+                : name === "parent-new"
+                  ? "parent-new"
+                  : name === "child"
+                    ? "child-head"
+                    : undefined,
+            ),
+          ),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const store = yield* Store;
+      const link = yield* stack.adopt("child", "parent", "parent-old");
+
+      expect(link.anchor).toBe("parent-old");
+      expect((yield* store.read()).links.find((item) => item.branch === "child")?.anchor).toBe(
+        "parent-old",
+      );
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("adopt rejects an explicit replay anchor outside the branch", () => {
+    const layer = stackTestLayer({
+      current: "child",
+      refs: [ref("dev", "dev-head"), ref("parent", "parent-new"), ref("child", "child-head")],
+      pulls: [pr(1, "parent", "dev"), pr(2, "child", "parent")],
+      bases: bases(["child", "parent", "shared-base"], ["child", "unrelated", "shared-base"]),
+      service: {
+        head: (name) =>
+          Effect.succeed(Option.fromNullishOr(name === "unrelated" ? name : undefined)),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const error = yield* Effect.flip(stack.adopt("child", "parent", "unrelated"));
+
+      expect(String(error)).toContain("unrelated is not an ancestor of child");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("adopt rejects trunk, self-parent, and cyclic links", () =>
     Effect.gen(function* () {
       const stack = yield* Stack;

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -4884,15 +4884,43 @@ describe("Stack", () => {
     15_000,
   );
 
-  it.effect("land rejects a non-positive repair depth", () => {
+  it.effect("land supports a root-only repair depth", () => {
+    const planTest = makeLand();
+    const doneTest = makeLand();
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const plan = yield* stack.land("stack-a", { repairDepth: 0 });
+
+      expect(plan).toContain("would merge #4 (stack-a)");
+      expect(plan.join("\n")).not.toContain("stack-b");
+    })
+      .pipe(Effect.provide(planTest.layer))
+      .pipe(
+        Effect.flatMap(() =>
+          Effect.gen(function* () {
+            const stack = yield* Stack;
+            const done = yield* stack.land("stack-a", { apply: true, repairDepth: 0 });
+
+            expect(done).toContain("merge #4 (stack-a)");
+            expect(done.join("\n")).not.toContain("stack-b");
+            expect(doneTest.seen).toContain("merge 4");
+            expect(doneTest.seen).not.toContain("edit 5 dev");
+            expect(doneTest.seen.some((item) => item.startsWith("rebase stack-b"))).toBe(false);
+          }).pipe(Effect.provide(doneTest.layer)),
+        ),
+      );
+  });
+
+  it.effect("land rejects a negative repair depth", () => {
     const test = makeLand();
 
     return Effect.gen(function* () {
       const stack = yield* Stack;
-      const error = yield* Effect.flip(stack.land("stack-a", { repairDepth: 0 }));
+      const error = yield* Effect.flip(stack.land("stack-a", { repairDepth: -1 }));
 
       expect(error).toBeInstanceOf(StackOperationError);
-      expect(error.message).toContain("--repair-depth must be a positive integer");
+      expect(error.message).toContain("--repair-depth must be a non-negative integer");
       expect(test.seen).toEqual([]);
     }).pipe(Effect.provide(test.layer));
   });

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -89,6 +89,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     head: () => Effect.succeed(Option.none()),
     base: () => Effect.succeed(Option.none()),
     commits: () => Effect.succeed([]),
+    semanticCommits: () => Effect.succeed({ commits: [], matchedParentPrefix: 0 }),
     novel: (_parent, _branch, commits) => Effect.succeed(commits),
     replay: () => Effect.void,
     unmergedPaths: () => Effect.succeed([] as ReadonlyArray<string>),
@@ -97,6 +98,8 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     drop: () => Effect.void,
     restore: () => Effect.void,
     push: () => Effect.void,
+    remoteHead: (_remote, branch) =>
+      service.head?.(branch) ?? Effect.succeed(Option.none<string>()),
     provider: "github",
     capabilities: { adminMerge: true },
     requestLabel: "PR",
@@ -135,17 +138,35 @@ const stackTestLayer = (opts: {
   readonly progress?: Array<Progress.ProgressEvent>;
 }) => {
   const pulls = opts.pulls ?? [];
+  const refs = new Map(opts.refs.map((item) => [String(item.name), item]));
+  const baseMap = new Map(Object.entries(opts.bases ?? {}));
+  let replaySequence = 0;
   return Stack.layer.pipe(
     Layer.provideMerge(opts.progress ? Progress.memory(opts.progress) : Progress.noop),
     Layer.provideMerge(cfg),
     Layer.provideMerge(
       gitAndCodeHost({
-        refs: () => Effect.succeed(opts.refs),
+        refs: () => Effect.succeed([...refs.values()]),
         changes: () => Effect.succeed(pulls),
         current: () => Effect.succeed(opts.current ?? ""),
-        head: (name) => Effect.succeed(Option.fromNullishOr(refsHead(opts.refs, name))),
+        head: (name) =>
+          Effect.succeed(
+            Option.fromNullishOr(
+              refs.get(name)?.head ??
+                (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined),
+            ),
+          ),
         base: (branch, parent) =>
-          Effect.succeed(Option.fromNullishOr(opts.bases?.[`${branch}:${parent}`])),
+          Effect.succeed(Option.fromNullishOr(baseMap.get(`${branch}:${parent}`))),
+        replay: (branch, parent) =>
+          Effect.sync(() => {
+            replaySequence += 1;
+            refs.set(branch, ref(branch, `${branch}-replayed-${replaySequence}`));
+            const parentHead =
+              refs.get(parent)?.head ??
+              (parent.startsWith("origin/") ? refs.get(parent.slice(7))?.head : undefined);
+            if (parentHead) baseMap.set(`${branch}:${parent}`, parentHead);
+          }),
         change: (number) => {
           const pull = pulls.find((item) => item.number === number);
           return pull
@@ -844,6 +865,7 @@ const makeLand = (
     ["stack-b", branchRef({ name: "stack-b", head: "stack-b-1" })],
     ["stack-c", branchRef({ name: "stack-c", head: "stack-c-1" })],
   ]);
+  let replaySequence = 1;
   if (includeUnrelatedRoot) {
     refs.set("other-root", branchRef({ name: "other-root", head: "other-root-1" }));
   }
@@ -993,7 +1015,8 @@ const makeLand = (
           replay: (branch: string, parent: string, _commits: ReadonlyArray<string>) =>
             Effect.sync(() => {
               seen.push(`rebase ${branch} ${parent}`);
-              refs.set(branch, branchRef({ name: branch, head: `${branch}-2` }));
+              replaySequence += 1;
+              refs.set(branch, branchRef({ name: branch, head: `${branch}-${replaySequence}` }));
               bases.set(`${branch}:${parent}`, refs.get(parent)?.head ?? "");
             }),
           release: (branch: string) => Effect.sync(() => void seen.push(`release ${branch}`)),
@@ -2410,14 +2433,14 @@ describe("Stack", () => {
 
   it.effect("sync infers a child anchor from the unchanged remote parent tip", () => {
     const commitRanges: Array<string> = [];
-    const refs = [
-      ref("dev", "dev-head"),
-      ref("parent", "parent-repaired"),
-      ref("child", "child-old"),
-    ];
+    const refs = new Map([
+      ["dev", ref("dev", "dev-head")],
+      ["parent", ref("parent", "parent-repaired")],
+      ["child", ref("child", "child-old")],
+    ]);
     const layer = stackTestLayer({
       current: "child",
-      refs,
+      refs: [...refs.values()],
       pulls: [pr(1, "parent", "dev"), pr(2, "child", "parent")],
       bases: bases(
         ["parent", "dev", "dev-head"],
@@ -2425,10 +2448,14 @@ describe("Stack", () => {
         ["child", "origin/parent", "parent-before-repair"],
       ),
       service: {
+        refs: () => Effect.succeed([...refs.values()]),
         head: (name) =>
           Effect.succeed(
             Option.fromNullishOr(
-              name === "origin/parent" ? "parent-before-repair" : refsHead(refs, name),
+              name === "origin/parent"
+                ? "parent-before-repair"
+                : (refs.get(name)?.head ??
+                    (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined)),
             ),
           ),
         commits: (from, branch) =>
@@ -2436,6 +2463,8 @@ describe("Stack", () => {
             commitRanges.push(`${from}:${branch}`);
             return ["child-only"];
           }),
+        replay: (branch) =>
+          Effect.sync(() => void refs.set(branch, ref(branch, `${branch}-replayed`))),
       },
     });
 
@@ -3183,10 +3212,11 @@ describe("Stack", () => {
                 ? ["parent-1", "parent-2", "child-only"]
                 : [],
           ),
-        novel: (_parent: string, _branch: string, commits: ReadonlyArray<string>) =>
-          Effect.succeed(commits),
-        replay: (branch: string, parent: string, commits: ReadonlyArray<string>) =>
-          Effect.sync(() => seen.push(`rebase ${branch} ${parent} ${commits.join(",")}`)),
+        novel: (parent: string, branch: string, commits: ReadonlyArray<string>) =>
+          Effect.sync(() => {
+            seen.push(`rebase ${branch} ${parent} ${commits.join(",")}`);
+            return commits;
+          }),
       },
     });
 
@@ -3223,10 +3253,11 @@ describe("Stack", () => {
                 ? ["parent-1", "parent-2", "child-only"]
                 : [],
           ),
-        novel: (_parent: string, _branch: string, commits: ReadonlyArray<string>) =>
-          Effect.succeed(commits),
-        replay: (branch: string, parent: string, commits: ReadonlyArray<string>) =>
-          Effect.sync(() => seen.push(`rebase ${branch} ${parent} ${commits.join(",")}`)),
+        novel: (parent: string, branch: string, commits: ReadonlyArray<string>) =>
+          Effect.sync(() => {
+            seen.push(`rebase ${branch} ${parent} ${commits.join(",")}`);
+            return commits;
+          }),
       },
     });
 
@@ -3236,6 +3267,81 @@ describe("Stack", () => {
 
       expect(seen).toContain("rebase child origin/dev child-only");
       expect(seen).not.toContain("rebase child origin/dev parent-1,parent-2,child-only");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect(
+    "sync does not record rebase or push when replay leaves the local head unchanged",
+    () => {
+      const layer = stackTestLayer({
+        current: "child",
+        refs: [ref("dev", "dev-new"), ref("child", "child-old")],
+        pulls: [pr(2, "child", "dev")],
+        bases: bases(["child", "origin/dev", "dev-old"]),
+        state: stackState([
+          stackLink({ branch: "child", parent: "dev", anchor: "dev-old", pr: 2 }),
+        ]),
+        service: {
+          commits: () => Effect.succeed(["child-only"]),
+          novel: (_parent, _branch, commits) => Effect.succeed(commits),
+          replay: () => Effect.void,
+        },
+      });
+
+      return Effect.gen(function* () {
+        const stack = yield* Stack;
+        const error = yield* Effect.flip(stack.sync({ apply: true }));
+        const history = yield* stack.last();
+
+        expect(String(error)).toContain("did not update local head");
+        expect(history).not.toContain("rebase child onto dev");
+        expect(history).not.toContain("push child");
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect("sync records rebase but not push when the remote head does not match", () => {
+    const refs = new Map([
+      ["dev", ref("dev", "dev-new")],
+      ["child", ref("child", "child-old")],
+    ]);
+    const baseMap = new Map([["child:origin/dev", "dev-old"]]);
+    const layer = stackTestLayer({
+      current: "child",
+      refs: [...refs.values()],
+      pulls: [pr(2, "child", "dev")],
+      state: stackState([stackLink({ branch: "child", parent: "dev", anchor: "dev-old", pr: 2 })]),
+      service: {
+        refs: () => Effect.succeed([...refs.values()]),
+        head: (name) =>
+          Effect.succeed(
+            Option.fromNullishOr(
+              refs.get(name)?.head ??
+                (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined),
+            ),
+          ),
+        base: (branch, parent) =>
+          Effect.succeed(Option.fromNullishOr(baseMap.get(`${branch}:${parent}`))),
+        commits: () => Effect.succeed(["child-only"]),
+        novel: (_parent, _branch, commits) => Effect.succeed(commits),
+        replay: (branch, parent) =>
+          Effect.sync(() => {
+            refs.set(branch, ref(branch, "child-new"));
+            baseMap.set(`${branch}:${parent}`, "dev-new");
+          }),
+        push: () => Effect.void,
+        remoteHead: () => Effect.succeed(Option.some("child-old")),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const error = yield* Effect.flip(stack.sync({ apply: true }));
+      const history = yield* stack.last();
+
+      expect(String(error)).toContain("origin head child-old does not match local head child-new");
+      expect(history).toContain("rebase child onto dev");
+      expect(history).not.toContain("push child");
     }).pipe(Effect.provide(layer));
   });
 
@@ -3377,9 +3483,11 @@ describe("Stack", () => {
       service: {
         commits: (from, branch) =>
           Effect.succeed(from === "root-old" && branch === "child" ? ["child-only"] : []),
-        novel: (_parent, _branch, commits) => Effect.succeed(commits),
-        replay: (branch, parent, commits) =>
-          Effect.sync(() => seen.push(`${branch}:${parent}:${commits.join(",")}`)),
+        novel: (parent, branch, commits) =>
+          Effect.sync(() => {
+            seen.push(`${branch}:${parent}:${commits.join(",")}`);
+            return commits;
+          }),
       },
     });
 
@@ -3809,6 +3917,168 @@ describe("Stack", () => {
       );
   });
 
+  it.effect(
+    "land isolates the immediate child's semantic suffix after a divergent root squash",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const origin = join(root, "origin.git");
+        const repo = join(root, "repo");
+        const log: Array<string> = [];
+
+        yield* shell(root, "git", ["init", "--bare", origin]);
+        yield* mkdirp(repo);
+        yield* shell(repo, "git", ["init", "-b", "dev"]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(repo, "git", ["remote", "add", "origin", origin]);
+
+        yield* commitFile(repo, "base.txt", "base\n", "base");
+        yield* shell(repo, "git", ["push", "-u", "origin", "dev"]);
+        const anchor = yield* shell(repo, "git", ["rev-parse", "dev"]);
+
+        yield* shell(repo, "git", ["checkout", "-b", "root"]);
+        const sharedParentBody = Array.from({ length: 20 }, (_, index) => `shared-${index}`).join(
+          "\n",
+        );
+        yield* commitFile(
+          repo,
+          "parent.txt",
+          `${sharedParentBody}\nparent-v2\n`,
+          "parent semantic layer",
+        );
+        yield* shell(repo, "git", ["push", "-u", "origin", "root"]);
+
+        yield* shell(repo, "git", ["checkout", "-b", "child", "dev"]);
+        yield* commitFile(
+          repo,
+          "parent.txt",
+          `${sharedParentBody}\nparent-v1\n`,
+          "parent semantic layer",
+        );
+        yield* commitFile(repo, "cleanup.txt", "cleanup\n", "child cleanup layer");
+        yield* shell(repo, "git", ["push", "-u", "origin", "child"]);
+        const originalChild = yield* shell(repo, "git", ["rev-parse", "child"]);
+
+        yield* shell(repo, "git", ["checkout", "-b", "grandchild"]);
+        yield* commitFile(repo, "grandchild.txt", "grandchild\n", "grandchild layer");
+        yield* shell(repo, "git", ["push", "-u", "origin", "grandchild"]);
+        const originalGrandchild = yield* shell(repo, "git", ["rev-parse", "grandchild"]);
+        yield* shell(repo, "git", ["checkout", "dev"]);
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["dev"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+        const layer = Stack.layer.pipe(
+          Layer.provideMerge(Progress.noop),
+          Layer.provideMerge(NodeServices.layer),
+          Layer.provideMerge(Proc.live),
+          Layer.provideMerge(cfgLayer),
+          Layer.provideMerge(Git.live.pipe(Layer.provide(cfgLayer))),
+          Layer.provideMerge(
+            integrationGitHub({
+              repo,
+              log,
+              pulls: [pr(1, "root", "dev"), pr(2, "child", "root"), pr(3, "grandchild", "child")],
+              metas: [
+                pullMeta({
+                  number: 1,
+                  title: "root",
+                  body: "Stacked on dev.",
+                  head: "root",
+                  base: "dev",
+                  url: "u1",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 2,
+                  title: "child",
+                  body: "Stacked on #1.",
+                  head: "child",
+                  base: "root",
+                  url: "u2",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 3,
+                  title: "grandchild",
+                  body: "Stacked on #2.",
+                  head: "grandchild",
+                  base: "child",
+                  url: "u3",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+              ],
+            }),
+          ),
+          Layer.provideMerge(
+            Store.memory(
+              new StackState({
+                version: 1,
+                links: [
+                  stackLink({ branch: "root", parent: "dev", anchor, pr: 1 }),
+                  stackLink({ branch: "child", parent: "root", anchor, pr: 2 }),
+                  stackLink({
+                    branch: "grandchild",
+                    parent: "child",
+                    anchor: originalChild,
+                    pr: 3,
+                  }),
+                ],
+              }),
+            ),
+          ),
+        );
+
+        const result = yield* Effect.gen(function* () {
+          const stack = yield* Stack;
+          const store = yield* Store;
+          const preview = yield* stack.land("root", { repairDepth: 1 });
+          const applied = yield* stack.land("root", { apply: true, repairDepth: 1 });
+          return { preview, applied, state: yield* store.read(), history: yield* stack.last() };
+        }).pipe(Effect.provide(layer));
+
+        const devHead = yield* shell(repo, "git", ["rev-parse", "dev"]);
+        const childHead = yield* shell(repo, "git", ["rev-parse", "child"]);
+        const remoteChildHead = yield* shell(repo, "git", ["rev-parse", "origin/child"]);
+        const childCommits = yield* shell(repo, "git", [
+          "rev-list",
+          "--reverse",
+          "--first-parent",
+          "--no-merges",
+          `${devHead}..${childHead}`,
+        ]);
+
+        expect(result.preview.join("\n")).toContain("would rebase child onto dev");
+        expect(result.preview.join("\n")).not.toContain("grandchild");
+        expect(result.applied.join("\n")).not.toContain("grandchild");
+        expect(childHead).not.toBe(originalChild);
+        expect(remoteChildHead).toBe(childHead);
+        expect(childCommits.split("\n").filter(Boolean)).toHaveLength(1);
+        expect(yield* shell(repo, "git", ["show", "-s", "--format=%s", childHead])).toBe(
+          "child cleanup layer",
+        );
+        expect(yield* shell(repo, "git", ["rev-parse", "grandchild"])).toBe(originalGrandchild);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/grandchild"])).toBe(
+          originalGrandchild,
+        );
+        expect(result.state.links.find((item) => item.branch === "child")?.parent).toBe("dev");
+        expect(result.state.links.find((item) => item.branch === "grandchild")?.parent).toBe(
+          "child",
+        );
+        expect(result.history).toContain("rebase child onto dev");
+        expect(result.history).toContain("push child");
+        expect(log).not.toContain("body 3");
+      }).pipe(Effect.provide(platform)),
+    15_000,
+  );
+
   it.effect("land rejects a non-positive repair depth", () => {
     const test = makeLand();
 
@@ -3907,7 +4177,11 @@ describe("Stack", () => {
         stackLink({ branch: "other-child", parent: "other-root", anchor: "other-old", pr: 4 }),
       ]),
       service: {
-        replay: (branch) => Effect.sync(() => void seen.push(`rebase ${branch}`)),
+        novel: (_parent, branch, commits) =>
+          Effect.sync(() => {
+            seen.push(`rebase ${branch}`);
+            return commits;
+          }),
         push: (branch) => Effect.sync(() => void seen.push(`push ${branch}`)),
         body: (number) => Effect.sync(() => void seen.push(`body ${number}`)),
       },
@@ -4553,60 +4827,63 @@ describe("Stack", () => {
     15_000,
   );
 
-  it.effect("sync rebases a deep stack when PR 2 is refactored", () =>
-    Effect.gen(function* () {
-      const scenario = yield* realStack({
-        branches: [
-          {
-            name: "stack-2",
-            parent: "dev",
-            number: 2,
-            commits: [{ file: "two.txt", body: "two\n", message: "two" }],
-          },
-          {
-            name: "stack-3",
-            parent: "stack-2",
-            number: 3,
-            commits: [{ file: "three.txt", body: "three\n", message: "three" }],
-          },
-          {
-            name: "stack-4",
-            parent: "stack-3",
-            number: 4,
-            commits: [{ file: "four.txt", body: "four\n", message: "four" }],
-          },
-          {
-            name: "stack-5",
-            parent: "stack-4",
-            number: 5,
-            commits: [{ file: "five.txt", body: "five\n", message: "five" }],
-          },
-        ],
-      });
+  it.effect(
+    "sync rebases a deep stack when PR 2 is refactored",
+    () =>
+      Effect.gen(function* () {
+        const scenario = yield* realStack({
+          branches: [
+            {
+              name: "stack-2",
+              parent: "dev",
+              number: 2,
+              commits: [{ file: "two.txt", body: "two\n", message: "two" }],
+            },
+            {
+              name: "stack-3",
+              parent: "stack-2",
+              number: 3,
+              commits: [{ file: "three.txt", body: "three\n", message: "three" }],
+            },
+            {
+              name: "stack-4",
+              parent: "stack-3",
+              number: 4,
+              commits: [{ file: "four.txt", body: "four\n", message: "four" }],
+            },
+            {
+              name: "stack-5",
+              parent: "stack-4",
+              number: 5,
+              commits: [{ file: "five.txt", body: "five\n", message: "five" }],
+            },
+          ],
+        });
 
-      yield* scenario.git(["checkout", "stack-2"]);
-      yield* commitFile(scenario.repo, "two-refactor.txt", "two refactor\n", "two refactor");
-      yield* scenario.git(["push", "origin", "stack-2"]);
+        yield* scenario.git(["checkout", "stack-2"]);
+        yield* commitFile(scenario.repo, "two-refactor.txt", "two refactor\n", "two refactor");
+        yield* scenario.git(["push", "origin", "stack-2"]);
 
-      const items = yield* Effect.gen(function* () {
-        const stack = yield* Stack;
-        return yield* stack.sync({ apply: true });
-      }).pipe(Effect.provide(scenario.layer));
+        const items = yield* Effect.gen(function* () {
+          const stack = yield* Stack;
+          return yield* stack.sync({ apply: true });
+        }).pipe(Effect.provide(scenario.layer));
 
-      expect(items).not.toContain("rebase stack-2 onto dev");
-      expect(items).toContain("   └─ ✓ stack-3 #3 rebased onto stack-2");
-      expect(items).toContain("      └─ ✓ stack-4 #4 rebased onto stack-3");
-      expect(items).toContain("         └─ ✓ stack-5 #5 rebased onto stack-4");
-      expect(yield* scenario.git(["merge-base", "stack-3", "stack-2"])).toBe(
-        yield* scenario.git(["rev-parse", "stack-2"]),
-      );
-      expect(yield* scenario.git(["merge-base", "stack-4", "stack-3"])).toBe(
-        yield* scenario.git(["rev-parse", "stack-3"]),
-      );
-      expect(yield* scenario.git(["merge-base", "stack-5", "stack-4"])).toBe(
-        yield* scenario.git(["rev-parse", "stack-4"]),
-      );
-    }).pipe(Effect.provide(platform)),
+        expect(items).not.toContain("rebase stack-2 onto dev");
+        expect(items).toContain("   └─ ✓ stack-3 #3 rebased onto stack-2");
+        expect(items).toContain("      └─ ✓ stack-4 #4 rebased onto stack-3");
+        expect(items).toContain("         └─ ✓ stack-5 #5 rebased onto stack-4");
+        expect(yield* scenario.git(["merge-base", "stack-3", "stack-2"])).toBe(
+          yield* scenario.git(["rev-parse", "stack-2"]),
+        );
+        expect(yield* scenario.git(["merge-base", "stack-4", "stack-3"])).toBe(
+          yield* scenario.git(["rev-parse", "stack-3"]),
+        );
+        expect(yield* scenario.git(["merge-base", "stack-5", "stack-4"])).toBe(
+          yield* scenario.git(["rev-parse", "stack-4"]),
+        );
+      }).pipe(Effect.provide(platform)),
+    15_000,
   );
 
   it.effect("sync is idempotent after repairing a moved parent", () =>
@@ -4645,130 +4922,126 @@ describe("Stack", () => {
     }).pipe(Effect.provide(platform)),
   );
 
-  it.effect(
-    "sync --apply does not re-push a child that is already current when its parent is repaired",
-    () => {
-      const refs = new Map([
-        ["dev", branchRef({ name: "dev", head: "dev-2" })],
-        ["stack-a", branchRef({ name: "stack-a", head: "stack-a-1" })],
-        ["stack-b", branchRef({ name: "stack-b", head: "stack-b-1" })],
-      ]);
-      const pulls = [
-        pullRef({ number: 4, head: "stack-a", base: "dev", url: "u4", draft: false }),
-        pullRef({ number: 5, head: "stack-b", base: "stack-a", url: "u5", draft: false }),
-      ];
-      const bases = new Map([
-        ["stack-a:dev", "dev-1"],
-        ["stack-a:origin/dev", "dev-1"],
-        ["stack-b:stack-a", "stack-a-1"],
-      ]);
-      const metas = new Map([
-        [
-          4,
-          pullMeta({
-            number: 4,
-            title: "stack-a",
-            body: "body",
-            head: "stack-a",
-            base: "dev",
-            url: "u4",
-            draft: false,
-            state: "OPEN",
-            labels: [],
-          }),
-        ],
-        [
-          5,
-          pullMeta({
-            number: 5,
-            title: "stack-b",
-            body: "body",
-            head: "stack-b",
-            base: "stack-a",
-            url: "u5",
-            draft: false,
-            state: "OPEN",
-            labels: [],
-          }),
-        ],
-      ]);
-      const seen: Array<string> = [];
+  it.effect("sync --apply rejects a parent repair that leaves its head unchanged", () => {
+    const refs = new Map([
+      ["dev", branchRef({ name: "dev", head: "dev-2" })],
+      ["stack-a", branchRef({ name: "stack-a", head: "stack-a-1" })],
+      ["stack-b", branchRef({ name: "stack-b", head: "stack-b-1" })],
+    ]);
+    const pulls = [
+      pullRef({ number: 4, head: "stack-a", base: "dev", url: "u4", draft: false }),
+      pullRef({ number: 5, head: "stack-b", base: "stack-a", url: "u5", draft: false }),
+    ];
+    const bases = new Map([
+      ["stack-a:dev", "dev-1"],
+      ["stack-a:origin/dev", "dev-1"],
+      ["stack-b:stack-a", "stack-a-1"],
+    ]);
+    const metas = new Map([
+      [
+        4,
+        pullMeta({
+          number: 4,
+          title: "stack-a",
+          body: "body",
+          head: "stack-a",
+          base: "dev",
+          url: "u4",
+          draft: false,
+          state: "OPEN",
+          labels: [],
+        }),
+      ],
+      [
+        5,
+        pullMeta({
+          number: 5,
+          title: "stack-b",
+          body: "body",
+          head: "stack-b",
+          base: "stack-a",
+          url: "u5",
+          draft: false,
+          state: "OPEN",
+          labels: [],
+        }),
+      ],
+    ]);
+    const seen: Array<string> = [];
 
-      const layer = Stack.layer.pipe(
-        Layer.provideMerge(Progress.noop),
-        Layer.provideMerge(NodeServices.layer),
-        Layer.provideMerge(
-          StackConfig.layer({ root: "/tmp/stack", trunks: ["dev"] }).pipe(
-            Layer.provide(NodeServices.layer),
-          ),
+    const layer = Stack.layer.pipe(
+      Layer.provideMerge(Progress.noop),
+      Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(
+        StackConfig.layer({ root: "/tmp/stack", trunks: ["dev"] }).pipe(
+          Layer.provide(NodeServices.layer),
         ),
-        Layer.provideMerge(
-          gitAndCodeHost({
-            dirty: () => Effect.succeed([]),
-            worktrees: () => Effect.succeed([]),
-            fetch: () => Effect.void,
-            refs: () => Effect.succeed(Array.from(refs.values())),
-            changes: () => Effect.succeed(pulls),
-            change: (pr: number) => Effect.succeed(metas.get(pr)!),
-            current: () => Effect.succeed("stack-b"),
-            head: (name: string) =>
-              Effect.succeed(
-                Option.fromNullishOr(
-                  refs.get(name)?.head ??
-                    (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined),
-                ),
+      ),
+      Layer.provideMerge(
+        gitAndCodeHost({
+          dirty: () => Effect.succeed([]),
+          worktrees: () => Effect.succeed([]),
+          fetch: () => Effect.void,
+          refs: () => Effect.succeed(Array.from(refs.values())),
+          changes: () => Effect.succeed(pulls),
+          change: (pr: number) => Effect.succeed(metas.get(pr)!),
+          current: () => Effect.succeed("stack-b"),
+          head: (name: string) =>
+            Effect.succeed(
+              Option.fromNullishOr(
+                refs.get(name)?.head ??
+                  (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined),
               ),
-            base: (branch: string, parent: string) =>
-              Effect.succeed(Option.fromNullishOr(bases.get(`${branch}:${parent}`))),
-            commits: () => Effect.succeed(["x"]),
-            novel: (_p: string, _b: string, commits: ReadonlyArray<string>) =>
-              Effect.succeed(commits),
-            backup: (branch: string, name: string) =>
-              Effect.sync(() => void seen.push(`backup ${branch} ${name}`)),
-            drop: () => Effect.void,
-            restore: () => Effect.void,
-            replay: (branch: string, parent: string) =>
-              Effect.sync(() => {
-                seen.push(`rebase ${branch} ${parent}`);
-              }),
-            push: (branch: string) => Effect.sync(() => void seen.push(`push ${branch}`)),
-            edit: (pr: number, base: string) =>
-              Effect.sync(() => void seen.push(`edit ${pr} ${base}`)),
-            body: (pr: number, body: string) =>
-              Effect.sync(() => void seen.push(`body ${pr} ${body.includes("### [Stack]")}`)),
-            close: () => Effect.void,
-            create: () =>
-              Effect.succeed(
-                pullRef({ number: 99, head: "x", base: "dev", url: "u", draft: false }),
-              ),
-            remote: () => Effect.succeed(Option.some("git@github.com:example/repo.git")),
-            remotes: () =>
-              Effect.succeed([{ name: "origin", url: "git@github.com:example/repo.git" }]),
-          }),
-        ),
-        Layer.provideMerge(
-          Store.memory(
-            new StackState({
-              version: 1,
-              links: [
-                stackLink({ branch: "stack-a", parent: "dev", anchor: "dev-1", pr: 4 }),
-                stackLink({ branch: "stack-b", parent: "stack-a", anchor: "stack-a-1", pr: 5 }),
-              ],
+            ),
+          base: (branch: string, parent: string) =>
+            Effect.succeed(Option.fromNullishOr(bases.get(`${branch}:${parent}`))),
+          commits: () => Effect.succeed(["x"]),
+          novel: (_p: string, _b: string, commits: ReadonlyArray<string>) =>
+            Effect.succeed(commits),
+          backup: (branch: string, name: string) =>
+            Effect.sync(() => void seen.push(`backup ${branch} ${name}`)),
+          drop: () => Effect.void,
+          restore: () => Effect.void,
+          replay: (branch: string, parent: string) =>
+            Effect.sync(() => {
+              seen.push(`rebase ${branch} ${parent}`);
             }),
-          ),
+          push: (branch: string) => Effect.sync(() => void seen.push(`push ${branch}`)),
+          edit: (pr: number, base: string) =>
+            Effect.sync(() => void seen.push(`edit ${pr} ${base}`)),
+          body: (pr: number, body: string) =>
+            Effect.sync(() => void seen.push(`body ${pr} ${body.includes("### [Stack]")}`)),
+          close: () => Effect.void,
+          create: () =>
+            Effect.succeed(pullRef({ number: 99, head: "x", base: "dev", url: "u", draft: false })),
+          remote: () => Effect.succeed(Option.some("git@github.com:example/repo.git")),
+          remotes: () =>
+            Effect.succeed([{ name: "origin", url: "git@github.com:example/repo.git" }]),
+        }),
+      ),
+      Layer.provideMerge(
+        Store.memory(
+          new StackState({
+            version: 1,
+            links: [
+              stackLink({ branch: "stack-a", parent: "dev", anchor: "dev-1", pr: 4 }),
+              stackLink({ branch: "stack-b", parent: "stack-a", anchor: "stack-a-1", pr: 5 }),
+            ],
+          }),
         ),
-      );
+      ),
+    );
 
-      return Effect.gen(function* () {
-        const stack = yield* Stack;
-        yield* stack.sync({ apply: true });
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const error = yield* Effect.flip(stack.sync({ apply: true }));
 
-        expect(seen).toContain("push stack-a");
-        expect(seen).not.toContain("rebase stack-b");
-        expect(seen).not.toContain("push stack-b");
-      }).pipe(Effect.provide(layer));
-    },
-  );
+      expect(String(error)).toContain("rebase stack-a did not update local head stack-a-1");
+      expect(seen).not.toContain("push stack-a");
+      expect(seen).not.toContain("rebase stack-b");
+      expect(seen).not.toContain("push stack-b");
+    }).pipe(Effect.provide(layer));
+  });
 
   it.effect("sync infers stack links in a real git repository", () =>
     Effect.gen(function* () {
@@ -5189,6 +5462,7 @@ describe("Stack", () => {
 describe("RepairExecution", () => {
   it.effect("checkpoints before applying a branch rebase", () => {
     const log: Array<string> = [];
+    let localHead = "old-head";
     const record = (line: string) => Effect.sync(() => void log.push(line));
 
     return RepairExecution.applyRebaseBranch(
@@ -5202,12 +5476,18 @@ describe("RepairExecution", () => {
       },
       {
         checkpoint: () => record("checkpoint"),
+        complete: (item) => record(`complete ${item._tag}`),
         step: (message) => record(`step ${message}`),
         git: {
           backup: (branch, backup) => record(`backup ${branch} ${backup}`),
           replay: (branch, onto, commits) =>
-            record(`replay ${branch} ${onto} ${commits.join(",")}`),
+            record(`replay ${branch} ${onto} ${commits.join(",")}`).pipe(
+              Effect.tap(() => Effect.sync(() => void (localHead = "new-head"))),
+            ),
           push: (branch, remote) => record(`push ${branch} ${remote}`),
+          head: (name) =>
+            Effect.succeed(Option.some(name === "origin/dev" ? "dev-head" : localHead)),
+          remoteHead: () => Effect.succeed(Option.some(localHead)),
         },
         onReplayFailure: (error) => error,
       },
@@ -5218,12 +5498,16 @@ describe("RepairExecution", () => {
             "checkpoint",
             "step backup stack-a -> backup/stack-a",
             "backup stack-a backup/stack-a",
+            "complete Backup",
             "step rebase stack-a onto dev",
             "replay stack-a origin/dev c1,c2",
+            "complete Rebase",
             "step push stack-a to fork",
             "push stack-a fork",
+            "complete Push",
             "step push stack-a",
             "push stack-a origin",
+            "complete Push",
           ]);
         }),
       ),
@@ -5247,11 +5531,14 @@ describe("RepairExecution", () => {
           },
           {
             checkpoint: () => Effect.fail(new StackOperationError("checkpoint failed")),
+            complete: () => Effect.void,
             step: (message) => record(`step ${message}`),
             git: {
               backup: (branch, backup) => record(`backup ${branch} ${backup}`),
               replay: (branch, onto) => record(`replay ${branch} ${onto}`),
               push: (branch, remote) => record(`push ${branch} ${remote}`),
+              head: (name) => Effect.succeed(Option.some(name === "origin/dev" ? "dev" : "old")),
+              remoteHead: () => Effect.succeed(Option.some("new")),
             },
             onReplayFailure: (error) => error,
           },

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1622,6 +1622,13 @@ describe("GitHub", () => {
             calls.push([tool, ...args]);
             if (args[0] === "repo") return JSON.stringify({ nameWithOwner: "alaro-ai/alaro" });
             if (args[0] === "api") {
+              if (args.some((arg) => arg.includes("HEAD_REF_FORCE_PUSHED_EVENT"))) {
+                return JSON.stringify({
+                  data: {
+                    repository: { pullRequest: { timelineItems: { nodes: [] } } },
+                  },
+                });
+              }
               return JSON.stringify({
                 data: {
                   repository: {
@@ -1657,16 +1664,19 @@ describe("GitHub", () => {
       const replayBase = yield* github.replayBase(101, "main");
 
       expect(Option.getOrUndefined(replayBase)).toEqual({
+        kind: "merged-parent",
         branch: "landed-parent",
         currentBase: "main",
         head: "exact-parent-head",
         fetchRef: "refs/pull/100/head",
         change: 100,
       });
-      expect(calls).toHaveLength(3);
+      expect(calls).toHaveLength(4);
       expect(calls[0]).toEqual(["gh", "repo", "view", "--json", "nameWithOwner"]);
       expect(calls[1]).toContain("number=101");
-      expect(calls[2]).toEqual([
+      expect(calls[1]).toContainEqual(expect.stringContaining("HEAD_REF_FORCE_PUSHED_EVENT"));
+      expect(calls[2]).toContain("number=101");
+      expect(calls[3]).toEqual([
         "gh",
         "pr",
         "list",
@@ -1679,6 +1689,103 @@ describe("GitHub", () => {
         "--limit",
         "100",
       ]);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("recovers an exact replay boundary from durable force-push history", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            if (args[0] === "repo") return JSON.stringify({ nameWithOwner: "alaro-ai/alaro" });
+            return JSON.stringify({
+              data: {
+                repository: {
+                  pullRequest: {
+                    timelineItems: {
+                      nodes: [
+                        {
+                          createdAt: "2026-08-03T12:48:55Z",
+                          beforeCommit: {
+                            oid: "a6600225",
+                            parents: { nodes: [{ oid: "35d69c1c" }] },
+                          },
+                          afterCommit: {
+                            oid: "67b27d90",
+                            parents: { nodes: [{ oid: "9c9bd6ed" }] },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            });
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const replayBase = yield* github.replayBase(3265, "main");
+
+      expect(Option.getOrUndefined(replayBase)).toEqual({
+        kind: "force-push-boundary",
+        currentBase: "main",
+        before: "a6600225",
+        semanticHead: "67b27d90",
+        boundary: "9c9bd6ed",
+      });
+      expect(calls).toHaveLength(2);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("fails closed when force-push history has an ambiguous boundary", () => {
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, _tool, args) =>
+          Effect.sync(() => {
+            if (args[0] === "repo") return JSON.stringify({ nameWithOwner: "alaro-ai/alaro" });
+            return JSON.stringify({
+              data: {
+                repository: {
+                  pullRequest: {
+                    timelineItems: {
+                      nodes: [
+                        {
+                          createdAt: "2026-08-03T12:48:55Z",
+                          beforeCommit: {
+                            oid: "before",
+                            parents: { nodes: [{ oid: "old-parent" }] },
+                          },
+                          afterCommit: {
+                            oid: "after",
+                            parents: { nodes: [{ oid: "parent-a" }, { oid: "parent-b" }] },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            });
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const error = yield* Effect.flip(github.replayBase(3265, "main"));
+
+      expect(String(error)).toContain("force-push history");
     }).pipe(
       Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
     );
@@ -3498,6 +3605,7 @@ describe("Stack", () => {
                 [
                   101,
                   {
+                    kind: "merged-parent",
                     branch: "landed-parent",
                     currentBase: "main",
                     head: landedParentHead,
@@ -3553,6 +3661,225 @@ describe("Stack", () => {
         );
         expect(yield* shell(repo, "git", ["cat-file", "-t", landedParentHead])).toBe("commit");
         expect(log).not.toContain("body 103");
+      }).pipe(Effect.provide(platform)),
+    20_000,
+  );
+
+  it.effect(
+    "sync uses the durable force-push boundary for the exact root cleanup suffix",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const origin = join(root, "origin.git");
+        const author = join(root, "author");
+        const repo = join(root, "fresh");
+        const log: Array<string> = [];
+
+        yield* shell(root, "git", ["init", "--bare", origin]);
+        yield* mkdirp(author);
+        yield* shell(author, "git", ["init", "-b", "main"]);
+        yield* shell(author, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(author, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(author, "git", ["remote", "add", "origin", origin]);
+
+        yield* commitFile(author, "base.txt", "base\n", "base");
+        const baseHead = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "main"]);
+        yield* shell(root, "git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "persisted-anchor"]);
+        yield* shell(author, "git", ["commit", "--allow-empty", "-m", "persisted stack anchor"]);
+        const anchor = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["checkout", "main"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "root", baseHead]);
+        yield* commitFile(
+          author,
+          "dismissal-table.py",
+          "legacy inherited migration\n",
+          "Add global email thread dismissal storage",
+        );
+        const forbiddenInheritedCommit = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* commitFile(
+          author,
+          "model-registry.py",
+          "legacy inherited registry\n",
+          "Register global dismissal storage",
+        );
+        const inheritedBoundary = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* commitFile(
+          author,
+          "cleanup.txt",
+          "remove legacy routes\n",
+          "Remove legacy email dismissal routes",
+        );
+        const semanticHead = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+
+        yield* shell(author, "git", [
+          "merge",
+          "--no-ff",
+          "persisted-anchor",
+          "-m",
+          "Merge child anchor state",
+        ]);
+        const childAnchor = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* commitFile(
+          author,
+          "cleanup.txt",
+          "remove legacy routes\nnotify safely\n",
+          "Fix dismissal notifications and retry handling",
+        );
+        yield* commitFile(
+          author,
+          "cleanup.txt",
+          "remove legacy routes\nnotify safely\nkeep cleanup\n",
+          "Keep dismissal cleanup after notify lookup failures",
+        );
+        const originalRoot = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "root"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "child"]);
+        yield* commitFile(
+          author,
+          "normalization.txt",
+          "retire\n",
+          "Retire dismissal normalization",
+        );
+        const originalChild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "child"]);
+        yield* shell(author, "git", ["checkout", "-b", "grandchild"]);
+        yield* commitFile(author, "naming.txt", "rename\n", "Inbound restore naming");
+        const originalGrandchild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "grandchild"]);
+        yield* shell(author, "git", ["checkout", "-b", "great-grandchild"]);
+        yield* commitFile(author, "triage.txt", "global\n", "Global triage internals");
+        const originalGreatGrandchild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "great-grandchild"]);
+
+        yield* shell(author, "git", ["checkout", "main"]);
+        yield* commitFile(
+          author,
+          "dismissal-table.py",
+          "legacy inherited migration\n",
+          "land inherited dismissal storage",
+        );
+        yield* commitFile(
+          author,
+          "model-registry.py",
+          "legacy inherited registry\n",
+          "land inherited registry",
+        );
+        yield* shell(author, "git", ["push", "origin", "main"]);
+
+        yield* shell(root, "git", ["clone", "--no-local", origin, repo]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(repo, "git", ["fetch", "origin", "root:root", "child:child"]);
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["main"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+        const layer = Stack.layer.pipe(
+          Layer.provideMerge(Progress.noop),
+          Layer.provideMerge(NodeServices.layer),
+          Layer.provideMerge(Proc.live),
+          Layer.provideMerge(cfgLayer),
+          Layer.provideMerge(Git.live.pipe(Layer.provide(cfgLayer))),
+          Layer.provideMerge(
+            integrationGitHub({
+              repo,
+              log,
+              pulls: [pr(3265, "root", "main"), pr(3267, "child", "root")],
+              metas: [
+                pullMeta({
+                  number: 3265,
+                  title: "legacy dismissal routes",
+                  body: "",
+                  head: "root",
+                  base: "main",
+                  url: "u3265",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 3267,
+                  title: "retire normalization",
+                  body: "",
+                  head: "child",
+                  base: "root",
+                  url: "u3267",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+              ],
+              replayBases: new Map([
+                [
+                  3265,
+                  {
+                    kind: "force-push-boundary",
+                    currentBase: "main",
+                    before: "unavailable-before-force-push",
+                    semanticHead,
+                    boundary: inheritedBoundary,
+                  },
+                ],
+              ]),
+            }),
+          ),
+          Layer.provideMerge(
+            Store.memory(
+              new StackState({
+                version: 1,
+                links: [
+                  stackLink({ branch: "root", parent: "main", anchor, pr: 3265 }),
+                  stackLink({ branch: "child", parent: "root", anchor: childAnchor, pr: 3267 }),
+                ],
+              }),
+            ),
+          ),
+        );
+
+        const result = yield* Effect.gen(function* () {
+          const stack = yield* Stack;
+          const preview = yield* stack.sync({ branch: "root" });
+          const applied = yield* stack.sync({ apply: true, branch: "root" });
+          return { preview, applied };
+        }).pipe(Effect.provide(layer));
+
+        const mainHead = yield* shell(repo, "git", ["rev-parse", "main"]);
+        const repairedRoot = yield* shell(repo, "git", ["rev-parse", "root"]);
+        const repairedSubjects = yield* shell(repo, "git", [
+          "log",
+          "--reverse",
+          "--first-parent",
+          "--no-merges",
+          "--format=%s",
+          `${mainHead}..${repairedRoot}`,
+        ]);
+
+        expect(result.preview.join("\n")).toContain("root #3265 would rebase onto main");
+        expect(result.preview.join("\n")).toContain("child #3267 would rebase onto root");
+        expect(result.applied.join("\n")).not.toContain("grandchild");
+        expect(repairedSubjects.split("\n")).toEqual([
+          "Remove legacy email dismissal routes",
+          "Fix dismissal notifications and retry handling",
+          "Keep dismissal cleanup after notify lookup failures",
+        ]);
+        expect(repairedSubjects).not.toContain("Add global email thread dismissal storage");
+        expect(repairedSubjects).not.toContain(forbiddenInheritedCommit);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/root"])).toBe(repairedRoot);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/child"])).not.toBe(originalChild);
+        expect(yield* shell(repo, "git", ["ls-remote", "origin", "refs/heads/grandchild"])).toBe(
+          `${originalGrandchild}\trefs/heads/grandchild`,
+        );
+        expect(
+          yield* shell(repo, "git", ["ls-remote", "origin", "refs/heads/great-grandchild"]),
+        ).toBe(`${originalGreatGrandchild}\trefs/heads/great-grandchild`);
+        expect(originalRoot).not.toBe(repairedRoot);
+        expect(log).not.toContain("body 3272");
+        expect(log).not.toContain("body 3274");
       }).pipe(Effect.provide(platform)),
     20_000,
   );

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -3484,6 +3484,59 @@ describe("Stack", () => {
     }).pipe(Effect.provide(test.layer));
   });
 
+  it.effect("sync prefers a persisted anchor shared by the root and trunk", () => {
+    const commitRequests: Array<string> = [];
+    const replayBaseRequests: Array<number> = [];
+    const layer = stackTestLayer({
+      current: "root",
+      refs: [ref("dev", "dev-new"), ref("root", "root-head")],
+      pulls: [pr(1, "root", "dev")],
+      state: stackState([stackLink({ branch: "root", parent: "dev", anchor: "dev-old", pr: 1 })]),
+      service: {
+        head: (name) => {
+          const heads: Readonly<Record<string, string>> = {
+            dev: "dev-new",
+            "origin/dev": "dev-new",
+            root: "root-head",
+            "dev-old": "dev-old",
+          };
+          return Effect.succeed(Option.fromNullishOr(heads[name]));
+        },
+        base: (branch, parent) => {
+          const sharedBase =
+            (branch === "root" && (parent === "origin/dev" || parent === "dev-old")) ||
+            (branch === "origin/dev" && parent === "dev-old");
+          return Effect.succeed(sharedBase ? Option.some("dev-old") : Option.none());
+        },
+        commits: (from, branch) =>
+          Effect.sync(() => {
+            commitRequests.push(`${from}..${branch}`);
+            return ["root-1", "root-2"];
+          }),
+        replayBase: (change) =>
+          Effect.sync(() => {
+            replayBaseRequests.push(change);
+            return Option.some<CodeHost.ReplayBase>({
+              kind: "force-push-boundary",
+              currentBase: "dev",
+              before: "old-root",
+              semanticHead: "root-1",
+              boundary: "inherited-boundary",
+            });
+          }),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const preview = yield* stack.sync({ branch: "root" });
+
+      expect(preview.join("\n")).toContain("root #1 would rebase onto dev");
+      expect(commitRequests).toEqual(["dev-old..root"]);
+      expect(replayBaseRequests).toEqual([1]);
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync uses stored child anchor after squash-merged parent is removed", () => {
     const seen: Array<string> = [];
     const pulls = [pr(2, "child", "dev")];

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -3229,6 +3229,68 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("sync refreshes a stale child anchor before retargeting its parent", () => {
+    const seen: Array<string> = [];
+    const refs = new Map([
+      ["dev", ref("dev", "dev-head")],
+      ["root", ref("root", "root-old-tip")],
+      ["child", ref("child", "child-old-tip")],
+    ]);
+    const baseMap = new Map([
+      ["root:dev", "dev-old"],
+      ["root:origin/dev", "dev-old"],
+      ["child:root", "root-old-tip"],
+    ]);
+    const pulls = [pr(1, "root", "dev"), pr(2, "child", "root")];
+    const layer = stackTestLayer({
+      current: "child",
+      refs: [...refs.values()],
+      pulls,
+      state: stackState([
+        stackLink({ branch: "root", parent: "legacy", anchor: "legacy-anchor", pr: 1 }),
+        stackLink({ branch: "child", parent: "root", anchor: "stale-child-anchor", pr: 2 }),
+      ]),
+      service: {
+        refs: () => Effect.succeed([...refs.values()]),
+        head: (name) =>
+          Effect.succeed(
+            Option.fromNullishOr(
+              refs.get(name)?.head ??
+                (name.startsWith("origin/") ? refs.get(name.slice(7))?.head : undefined),
+            ),
+          ),
+        base: (branch, parent) =>
+          Effect.succeed(Option.fromNullishOr(baseMap.get(`${branch}:${parent}`))),
+        commits: (from, branch) =>
+          Effect.succeed(
+            branch === "root" && from === "legacy-anchor"
+              ? ["root-only"]
+              : branch === "child" && from === "root-old-tip"
+                ? ["child-only"]
+                : branch === "child" && from === "stale-child-anchor"
+                  ? ["legacy-parent", "root-only", "child-only"]
+                  : [],
+          ),
+        novel: (_parent, _branch, commits) => Effect.succeed(commits),
+        replay: (branch, parent, commits) =>
+          Effect.sync(() => {
+            seen.push(`${branch}:${commits.join(",")}`);
+            const repairedHead = `${branch}-repaired`;
+            refs.set(branch, ref(branch, repairedHead));
+            baseMap.set(`${branch}:${parent}`, refs.get(parent)?.head ?? "");
+          }),
+      },
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      yield* stack.sync({ apply: true });
+
+      expect(seen).toEqual(["root:root-only", "child:child-only"]);
+      expect(seen.join(",")).not.toContain("legacy-parent");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync leaves a clean root alone when only the trunk advanced", () => {
     const seen: Array<string> = [];
     const layer = stackTestLayer({

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -2468,6 +2468,24 @@ describe("Stack", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("branch-scoped sync preview preserves its scope in the apply command", () => {
+    const layer = stackTestLayer({
+      current: "dev",
+      refs: [ref("dev", "aaa"), ref("app-root", "app"), ref("app-child", "app-child")],
+      pulls: [pr(1, "app-root", "dev"), pr(2, "app-child", "app-root")],
+      bases: bases(["app-root", "dev", "aaa"], ["app-child", "app-root", "app"]),
+    });
+
+    return Effect.gen(function* () {
+      const stack = yield* Stack;
+      const items = yield* stack.sync({ branch: "app-child" });
+
+      expect(items).toContain("Apply:");
+      expect(items).toContain("  stack sync app-child --apply");
+      expect(items).not.toContain("  stack sync --apply");
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("sync without branch scopes to the current inferred stack", () => {
     const layer = stackTestLayer({
       current: "other-child",

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -81,6 +81,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     dirty: () => Effect.succeed([]),
     worktrees: () => Effect.succeed([]),
     fetch: () => Effect.void,
+    fetchRef: (ref) => Effect.succeed(ref),
     remotes: () => Effect.succeed([]),
     refs: () => Effect.succeed([]),
     current: () => Effect.succeed(""),
@@ -111,6 +112,7 @@ const gitAndCodeHost = (service: Partial<Git.Interface & CodeHost.Interface>) =>
     wait: () => Effect.void,
     changes: () => Effect.succeed([]),
     change: (number) => Effect.fail(new CodeHostChangeNotFoundError(number)),
+    replayBase: () => Effect.succeed(Option.none()),
     edit: () => Effect.void,
     body: () => Effect.void,
     close: () => Effect.void,
@@ -209,6 +211,7 @@ const integrationGitHub = (opts: {
   readonly pulls: ReadonlyArray<ReturnType<typeof pullRef>>;
   readonly metas: ReadonlyArray<ReturnType<typeof pullMeta>>;
   readonly log: Array<string>;
+  readonly replayBases?: ReadonlyMap<number, CodeHost.ReplayBase>;
 }) =>
   Layer.effect(
     CodeHost.Service,
@@ -338,6 +341,12 @@ const integrationGitHub = (opts: {
         wait: (pr) => record(`wait ${pr}`),
         changes: listOpen,
         change: getPull,
+        replayBase: (pr, currentBase) => {
+          const value = opts.replayBases?.get(pr);
+          return Effect.succeed(
+            value?.currentBase === currentBase ? Option.some(value) : Option.none(),
+          );
+        },
         edit,
         body: updateBody,
         close: (pr) => Ref.update(pulls, (items) => items.filter((item) => item.number !== pr)),
@@ -1575,9 +1584,106 @@ describe("Git", () => {
       ]);
     }).pipe(Effect.provide(Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))));
   });
+
+  it.effect("fetches a durable code-host ref and returns its exact head", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            return args[0] === "rev-parse" ? "parent-head" : "";
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const git = yield* Git.Service;
+      const head = yield* git.fetchRef("refs/pull/100/head");
+
+      expect(head).toBe("parent-head");
+      expect(calls).toEqual([
+        ["git", "fetch", "origin", "--no-tags", "refs/pull/100/head"],
+        ["git", "rev-parse", "FETCH_HEAD"],
+      ]);
+    }).pipe(Effect.provide(Git.live.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))));
+  });
 });
 
 describe("GitHub", () => {
+  it.effect("recovers the exact landed parent head from a base-change event", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            if (args[0] === "repo") return JSON.stringify({ nameWithOwner: "alaro-ai/alaro" });
+            if (args[0] === "api") {
+              return JSON.stringify({
+                data: {
+                  repository: {
+                    pullRequest: {
+                      timelineItems: {
+                        nodes: [
+                          {
+                            createdAt: "2026-08-07T07:44:01Z",
+                            previousRefName: "landed-parent",
+                            currentRefName: "main",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              });
+            }
+            return JSON.stringify([
+              {
+                number: 100,
+                headRefName: "landed-parent",
+                headRefOid: "exact-parent-head",
+                mergedAt: "2026-08-07T07:44:04Z",
+              },
+            ]);
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const replayBase = yield* github.replayBase(101, "main");
+
+      expect(Option.getOrUndefined(replayBase)).toEqual({
+        branch: "landed-parent",
+        currentBase: "main",
+        head: "exact-parent-head",
+        fetchRef: "refs/pull/100/head",
+        change: 100,
+      });
+      expect(calls).toHaveLength(3);
+      expect(calls[0]).toEqual(["gh", "repo", "view", "--json", "nameWithOwner"]);
+      expect(calls[1]).toContain("number=101");
+      expect(calls[2]).toEqual([
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "merged",
+        "--head",
+        "landed-parent",
+        "--json",
+        "number,headRefName,headRefOid,mergedAt",
+        "--limit",
+        "100",
+      ]);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
   it.effect("wait polls with the configured interval", () => {
     const calls: Array<ReadonlyArray<string>> = [];
     let views = 0;
@@ -3269,6 +3375,187 @@ describe("Stack", () => {
       expect(seen).not.toContain("rebase child origin/dev parent-1,parent-2,child-only");
     }).pipe(Effect.provide(layer));
   });
+
+  it.effect(
+    "sync recovers a deleted landed parent from durable host state in a fresh clone",
+    () =>
+      Effect.gen(function* () {
+        const root = yield* tempDir();
+        const origin = join(root, "origin.git");
+        const author = join(root, "author");
+        const repo = join(root, "fresh");
+        const log: Array<string> = [];
+
+        yield* shell(root, "git", ["init", "--bare", origin]);
+        yield* mkdirp(author);
+        yield* shell(author, "git", ["init", "-b", "main"]);
+        yield* shell(author, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(author, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(author, "git", ["remote", "add", "origin", origin]);
+
+        yield* commitFile(author, "base.txt", "base\n", "base");
+        yield* shell(author, "git", ["push", "-u", "origin", "main"]);
+        yield* shell(root, "git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
+        const anchor = yield* shell(author, "git", ["rev-parse", "main"]);
+
+        const sharedParentBody = Array.from({ length: 20 }, (_, index) => `shared-${index}`).join(
+          "\n",
+        );
+        yield* shell(author, "git", ["checkout", "-b", "landed-parent", "main"]);
+        yield* commitFile(
+          author,
+          "parent.txt",
+          `${sharedParentBody}\nparent-v2\n`,
+          "landed parent semantic layer",
+        );
+        const landedParentHead = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "landed-parent"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "root", "main"]);
+        yield* commitFile(
+          author,
+          "parent.txt",
+          `${sharedParentBody}\nparent-v1\n`,
+          "inherited parent semantic layer",
+        );
+        const inheritedParentCommit = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* commitFile(author, "cleanup.txt", "cleanup\n", "root cleanup layer");
+        const originalRoot = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "root"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "child"]);
+        yield* commitFile(author, "child.txt", "child\n", "immediate child layer");
+        const originalChild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "child"]);
+
+        yield* shell(author, "git", ["checkout", "-b", "grandchild"]);
+        yield* commitFile(author, "grandchild.txt", "grandchild\n", "deeper descendant layer");
+        const originalGrandchild = yield* shell(author, "git", ["rev-parse", "HEAD"]);
+        yield* shell(author, "git", ["push", "-u", "origin", "grandchild"]);
+
+        yield* shell(author, "git", ["checkout", "main"]);
+        yield* shell(author, "git", ["merge", "--squash", "landed-parent"]);
+        yield* shell(author, "git", ["commit", "-m", "squash landed parent"]);
+        yield* shell(author, "git", ["push", "origin", "main"]);
+        yield* shell(root, "git", [
+          "--git-dir",
+          origin,
+          "update-ref",
+          "refs/pull/100/head",
+          landedParentHead,
+        ]);
+        yield* shell(author, "git", ["push", "origin", "--delete", "landed-parent"]);
+
+        yield* shell(root, "git", ["clone", "--no-local", origin, repo]);
+        yield* shell(repo, "git", ["config", "user.email", "stack@example.com"]);
+        yield* shell(repo, "git", ["config", "user.name", "Stack Test"]);
+        yield* shell(repo, "git", ["fetch", "origin", "root:root", "child:child"]);
+        const unavailableParent = yield* Effect.flip(
+          shell(repo, "git", ["cat-file", "-e", `${landedParentHead}^{commit}`]),
+        );
+        expect(unavailableParent).toBeInstanceOf(ExecError);
+        expect(yield* shell(repo, "git", ["branch", "--list", "landed-parent"])).toBe("");
+
+        const cfgLayer = StackConfig.layer({ root: repo, trunks: ["main"] }).pipe(
+          Layer.provide(NodeServices.layer),
+        );
+        const layer = Stack.layer.pipe(
+          Layer.provideMerge(Progress.noop),
+          Layer.provideMerge(NodeServices.layer),
+          Layer.provideMerge(Proc.live),
+          Layer.provideMerge(cfgLayer),
+          Layer.provideMerge(Git.live.pipe(Layer.provide(cfgLayer))),
+          Layer.provideMerge(
+            integrationGitHub({
+              repo,
+              log,
+              pulls: [pr(101, "root", "main"), pr(102, "child", "root")],
+              metas: [
+                pullMeta({
+                  number: 101,
+                  title: "root cleanup",
+                  body: "",
+                  head: "root",
+                  base: "main",
+                  url: "u101",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+                pullMeta({
+                  number: 102,
+                  title: "immediate child",
+                  body: "",
+                  head: "child",
+                  base: "root",
+                  url: "u102",
+                  draft: false,
+                  state: "OPEN",
+                  labels: [],
+                }),
+              ],
+              replayBases: new Map([
+                [
+                  101,
+                  {
+                    branch: "landed-parent",
+                    currentBase: "main",
+                    head: landedParentHead,
+                    fetchRef: "refs/pull/100/head",
+                    change: 100,
+                  },
+                ],
+              ]),
+            }),
+          ),
+          Layer.provideMerge(
+            Store.memory(
+              new StackState({
+                version: 1,
+                links: [
+                  stackLink({ branch: "root", parent: "main", anchor, pr: 101 }),
+                  stackLink({ branch: "child", parent: "root", anchor: originalRoot, pr: 102 }),
+                ],
+              }),
+            ),
+          ),
+        );
+
+        const result = yield* Effect.gen(function* () {
+          const stack = yield* Stack;
+          const preview = yield* stack.sync({ branch: "root" });
+          const applied = yield* stack.sync({ apply: true, branch: "root" });
+          return { preview, applied };
+        }).pipe(Effect.provide(layer));
+
+        const mainHead = yield* shell(repo, "git", ["rev-parse", "main"]);
+        const rootHead = yield* shell(repo, "git", ["rev-parse", "root"]);
+        const rootCommits = yield* shell(repo, "git", [
+          "rev-list",
+          "--reverse",
+          "--first-parent",
+          "--no-merges",
+          `${mainHead}..${rootHead}`,
+        ]);
+
+        expect(result.preview.join("\n")).toContain("root #101 would rebase onto main");
+        expect(result.preview.join("\n")).toContain("child #102 would rebase onto root");
+        expect(result.applied.join("\n")).not.toContain("grandchild");
+        expect(rootCommits.split("\n").filter(Boolean)).toEqual([rootHead]);
+        expect(rootCommits).not.toContain(inheritedParentCommit);
+        expect(yield* shell(repo, "git", ["show", "-s", "--format=%s", rootHead])).toBe(
+          "root cleanup layer",
+        );
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/root"])).toBe(rootHead);
+        expect(yield* shell(repo, "git", ["rev-parse", "origin/child"])).not.toBe(originalChild);
+        expect(yield* shell(repo, "git", ["ls-remote", "origin", "refs/heads/grandchild"])).toBe(
+          `${originalGrandchild}\trefs/heads/grandchild`,
+        );
+        expect(yield* shell(repo, "git", ["cat-file", "-t", landedParentHead])).toBe("commit");
+        expect(log).not.toContain("body 103");
+      }).pipe(Effect.provide(platform)),
+    20_000,
+  );
 
   it.effect(
     "sync does not record rebase or push when replay leaves the local head unchanged",

--- a/tests/stack.test.ts
+++ b/tests/stack.test.ts
@@ -1854,6 +1854,231 @@ describe("GitHub", () => {
     );
   });
 
+  it.effect("uses GitHub's asynchronous API for a native stacked PR", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            const endpoint = args.find((arg) => arg.startsWith("repos/"));
+            if (endpoint === "repos/{owner}/{repo}/pulls/7") {
+              return JSON.stringify({
+                head: { sha: "expected-head" },
+                stack: { number: 12 },
+              });
+            }
+            if (endpoint === "repos/{owner}/{repo}/stacks/12") {
+              return JSON.stringify({
+                pull_requests: [
+                  { number: 5, state: "closed", merged_at: "2026-01-01T00:00:00Z" },
+                  { number: 7, state: "open", merged_at: null },
+                  { number: 8, state: "open", merged_at: null },
+                ],
+              });
+            }
+            if (args.includes("--method")) {
+              return JSON.stringify({ status: "pending", details: { uuid: "request-id" } });
+            }
+            if (endpoint === "repos/{owner}/{repo}/pulls/7/merge-async/request-id") {
+              return JSON.stringify({ status: "merged", details: { sha: "merge-head" } });
+            }
+            throw new Error(`Unexpected command: ${args.join(" ")}`);
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      yield* github.merge(7);
+
+      expect(calls).toEqual([
+        ["gh", "api", "repos/{owner}/{repo}/pulls/7"],
+        ["gh", "api", "repos/{owner}/{repo}/stacks/12"],
+        [
+          "gh",
+          "api",
+          "--method",
+          "PUT",
+          "repos/{owner}/{repo}/pulls/7/merge-async",
+          "-f",
+          "merge_method=squash",
+          "-f",
+          "merge_action=direct_merge",
+          "-f",
+          "sha=expected-head",
+        ],
+        ["gh", "api", "repos/{owner}/{repo}/pulls/7/merge-async/request-id"],
+      ]);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("accepts GitHub's idempotent pending response after a repeated submission", () => {
+    const submitOkCodes: Array<ReadonlyArray<number> | undefined> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args, ok) => {
+          const endpoint = args.find((arg) => arg.startsWith("repos/"));
+          if (endpoint === "repos/{owner}/{repo}/pulls/7") {
+            return Effect.succeed(
+              JSON.stringify({ head: { sha: "expected-head" }, stack: { number: 12 } }),
+            );
+          }
+          if (endpoint === "repos/{owner}/{repo}/stacks/12") {
+            return Effect.succeed(
+              JSON.stringify({
+                pull_requests: [{ number: 7, state: "open", merged_at: null }],
+              }),
+            );
+          }
+          if (args.includes("--method")) {
+            submitOkCodes.push(ok);
+            return ok?.includes(1)
+              ? Effect.succeed(
+                  JSON.stringify({ status: "pending", details: { uuid: "existing-request" } }),
+                )
+              : Effect.fail(new ExecError(tool, args, 1, "Conflict (HTTP 409)"));
+          }
+          return Effect.succeed(
+            JSON.stringify({ status: "merged", details: { sha: "merge-head" } }),
+          );
+        },
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      yield* github.merge(7);
+
+      expect(submitOkCodes).toEqual([[0, 1]]);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("fails before a native stack merge would include another open PR", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            const endpoint = args.find((arg) => arg.startsWith("repos/"));
+            if (endpoint === "repos/{owner}/{repo}/pulls/7") {
+              return JSON.stringify({ head: { sha: "expected-head" }, stack: { number: 12 } });
+            }
+            if (endpoint === "repos/{owner}/{repo}/stacks/12") {
+              return JSON.stringify({
+                pull_requests: [
+                  { number: 5, state: "open", merged_at: null },
+                  { number: 7, state: "open", merged_at: null },
+                ],
+              });
+            }
+            throw new Error(`Unexpected command: ${args.join(" ")}`);
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const error = yield* Effect.flip(github.merge(7));
+
+      expect(error._tag).toBe("ExecError");
+      if (error._tag !== "ExecError") return;
+      expect(error.stderr).toContain("would also merge open PR #5");
+      expect(calls).toHaveLength(2);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("keeps the legacy merge path for a non-stacked PR", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            return args[0] === "api"
+              ? JSON.stringify({ head: { sha: "expected-head" }, stack: null })
+              : "";
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      yield* github.merge(7, { admin: true });
+
+      expect(calls).toEqual([
+        ["gh", "api", "repos/{owner}/{repo}/pulls/7"],
+        ["gh", "pr", "merge", "7", "--squash", "--admin"],
+      ]);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("rejects admin bypass for a native stacked PR", () => {
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, _tool, _args) =>
+          Effect.succeed(JSON.stringify({ head: { sha: "expected-head" }, stack: { number: 12 } })),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      const error = yield* Effect.flip(github.merge(7, { admin: true }));
+
+      expect(error._tag).toBe("UnsupportedCodeHostOperation");
+      expect(error.message).toContain("native stacked PR admin merge");
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
+  it.effect("submits a native stacked PR for default merge handling in auto mode", () => {
+    const calls: Array<ReadonlyArray<string>> = [];
+    const proc = Layer.succeed(
+      Proc.Service,
+      Proc.Service.of({
+        exec: (_cwd, tool, args) =>
+          Effect.sync(() => {
+            calls.push([tool, ...args]);
+            const endpoint = args.find((arg) => arg.startsWith("repos/"));
+            if (endpoint === "repos/{owner}/{repo}/pulls/7") {
+              return JSON.stringify({ head: { sha: "expected-head" }, stack: { number: 12 } });
+            }
+            if (endpoint === "repos/{owner}/{repo}/stacks/12") {
+              return JSON.stringify({
+                pull_requests: [{ number: 7, state: "open", merged_at: null }],
+              });
+            }
+            return JSON.stringify({ status: "enqueued", details: {} });
+          }),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const github = yield* CodeHost.Service;
+      yield* github.auto(7);
+
+      expect(calls.at(-1)).toContain("merge_action=default");
+      expect(calls.some((call) => call[1] === "pr" && call[2] === "merge")).toBe(false);
+    }).pipe(
+      Effect.provide(CodeHostGitHub.layer.pipe(Layer.provideMerge(cfg), Layer.provideMerge(proc))),
+    );
+  });
+
   it.effect("normalizes repository identity for fork push routing", () => {
     const proc = Layer.succeed(
       Proc.Service,


### PR DESCRIPTION
## Summary

- detect GitHub-native stack metadata before merging
- use GitHub's asynchronous stack merge API with the expected head SHA
- fail closed when the selected PR would also merge another open lower PR
- preserve the legacy merge path for ordinary pull requests

## Verification

- `bun run typecheck`
- `bun run test` (163 tests)
- `bun run format:check`
- `bun run lint`
- `bun run build`
- live merge of alaro-ai/alaro#3700 through the repaired path